### PR TITLE
While our code remains private, pivot to use SSH_AUTH_SOCK for the Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=ssh \
+    go mod download
 
 # Copy the go source
 COPY cmd/ cmd/
@@ -25,7 +27,9 @@ COPY pkg/ pkg/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o capis cmd/apiserver/main.go
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=ssh \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o capis cmd/apiserver/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ all: codegen fmt vet lint test tidy
 
 docker:
 	GOOS=linux GOARCH=arm64 go build -o install/bin/apiserver
-	docker build install --tag apiserver-caas:v0.0.0
+	docker build install --tag apiserver-caas:v0.0.0 --ssh default=$(SSH_AUTH_SOCK)
 
 .PHONY:
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build . -t ${IMG} --ssh default=$(SSH_AUTH_SOCK)
 
 .PHONY: docker-push
 docker-push:  docker-build ## Push docker image with the manager.


### PR DESCRIPTION
This is to fix `go mod download` as it tries to download private libraries in the iptecharch org.
This will make sure we can use CI pipelines with a private key stashed in the secret. The private runner will load the SSH key and add it to the ssh-agent, build the docker image and upload it to (several) private registries.