### PR TITLE
omit period and concurrent scans

### DIFF
--- a/apis/inv/v1alpha1/discoveryrule_interfaces.go
+++ b/apis/inv/v1alpha1/discoveryrule_interfaces.go
@@ -134,7 +134,7 @@ func (r *DiscoveryRule) GetSvcSelector() metav1.LabelSelector {
 }
 
 func (r *DiscoveryRule) Validate() error {
-
+	// kind identifies if this is a prefix, address, svc or pod kind
 	kind, err := r.GetDiscoveryKind()
 	if err != nil {
 		return err

--- a/apis/inv/v1alpha1/discoveryrule_parameters.go
+++ b/apis/inv/v1alpha1/discoveryrule_parameters.go
@@ -21,6 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r DiscoveryParameters) Validate() error {
@@ -46,6 +49,20 @@ func (r DiscoveryParameters) Validate() error {
 		}
 	}
 	return errm
+}
+
+func (r DiscoveryParameters) GetPeriod() metav1.Duration {
+	if r.Period.Duration == 0 {
+		return metav1.Duration{Duration: 1 * time.Minute}
+	}
+	return r.Period
+}
+
+func (r DiscoveryParameters) GetConcurrentScans() int64 {
+	if r.ConcurrentScans == 0 {
+		return 10
+	}
+	return r.ConcurrentScans
 }
 
 func (r DiscoveryParameters) GetTargetLabels(name string) (map[string]string, error) {

--- a/apis/inv/v1alpha1/discoveryrule_types.go
+++ b/apis/inv/v1alpha1/discoveryrule_types.go
@@ -58,10 +58,8 @@ type DiscoveryParameters struct {
 	TargetConnectionProfiles []TargetProfile `json:"targetConnectionProfiles" yaml:"targetConnectionProfiles"`
 	// TargetTemplate defines the template the discovery controller uses to create the targets as a result of the discovery
 	TargetTemplate *TargetTemplate `json:"targetTemplate,omitempty" yaml:"targetTemplate,omitempty"`
-	// +kubebuilder:default:="1m"
 	// Period defines the wait period between discovery rule runs
 	Period metav1.Duration `json:"period,omitempty" yaml:"period,omitempty"`
-	// +kubebuilder:default:=10
 	// number of concurrent IP scan
 	ConcurrentScans int64 `json:"concurrentScans,omitempty" yaml:"concurrentScans,omitempty"`
 }

--- a/artifacts/inv.sdcio.dev_discoveryrules.yaml
+++ b/artifacts/inv.sdcio.dev_discoveryrules.yaml
@@ -57,7 +57,6 @@ spec:
                   type: object
                 type: array
               concurrentScans:
-                default: 10
                 description: number of concurrent IP scan
                 format: int64
                 type: integer
@@ -101,7 +100,6 @@ spec:
                 - credentials
                 type: object
               period:
-                default: 1m
                 description: Period defines the wait period between discovery rule
                   runs
                 type: string

--- a/pkg/discovery/discoveryrule/discover.go
+++ b/pkg/discovery/discoveryrule/discover.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/henderiw/logger/log"
-	"github.com/iptecharch/config-server/apis/inv/v1alpha1"
 	invv1alpha1 "github.com/iptecharch/config-server/apis/inv/v1alpha1"
 )
 
@@ -40,7 +39,7 @@ func (r *dr) discover(ctx context.Context, h *hostInfo, targets *targets) error 
 // retruns the profiles used for discovery; if discovery was already done we retry with the same profile first
 // this function returns the discovery connection profile list and the order is changed based on the fact discovery
 // was already done
-func (r *dr) getDiscoveryProfiles(ctx context.Context, h *hostInfo, targets *targets) []*v1alpha1.TargetConnectionProfile {
+func (r *dr) getDiscoveryProfiles(ctx context.Context, h *hostInfo, targets *targets) []*invv1alpha1.TargetConnectionProfile {
 	address := h.Address
 
 	found := false // represent the status of the fact that we found the initial discovery profile

--- a/pkg/discovery/discoveryrule/discover_gnmi.go
+++ b/pkg/discovery/discoveryrule/discover_gnmi.go
@@ -79,7 +79,7 @@ func CreateTarget(ctx context.Context, address string, secret *corev1.Secret, co
 		api.Password(string(secret.Data["password"])),
 		api.Timeout(5 * time.Second),
 	}
-	if connProfile.Spec.Insecure == true {
+	if connProfile.Spec.Insecure  {
 		tOpts = append(tOpts, api.Insecure(true))
 	} else {
 		tOpts = append(tOpts, api.SkipVerify(true))

--- a/pkg/discovery/discoveryrule/rule.go
+++ b/pkg/discovery/discoveryrule/rule.go
@@ -59,7 +59,7 @@ func (r *dr) Run(ctx context.Context) error {
 				time.Sleep(5 * time.Second)
 			} else {
 				log.Info("discovery rule finished, waiting for next run")
-				time.Sleep(r.cfg.CR.GetDiscoveryParameters().Period.Duration)
+				time.Sleep(r.cfg.CR.GetDiscoveryParameters().GetPeriod().Duration)
 			}
 		}
 	}
@@ -76,7 +76,7 @@ func (r *dr) run(ctx context.Context) error {
 		return err // happens only of the apiserver is unresponsive
 	}
 
-	sem := semaphore.NewWeighted(r.cfg.CR.GetDiscoveryParameters().ConcurrentScans)
+	sem := semaphore.NewWeighted(r.cfg.CR.GetDiscoveryParameters().GetConcurrentScans())
 	for {
 		// Blocks until a next resource comes available
 		err = sem.Acquire(ctx, 1)


### PR DESCRIPTION
omit period and concurrent scan from the api
- if not specified: 
     - period will default to 1 minute in case of dynamic discovery
     - concurrent scans will default to 10