### PR TITLE
updated artifacts to make creds optional in schema crd

### DIFF
--- a/apis/generated/openapi/zz_generated.openapi.go
+++ b/apis/generated/openapi/zz_generated.openapi.go
@@ -1437,6 +1437,13 @@ func schema_config_server_apis_inv_v1alpha1_DiscoveryRuleSpec(ref common.Referen
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
 						},
 					},
+					"domainName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DomainName defines the domain name of the cluster, used by pod or svc discovery to identify the domain name in the l8s cluster where the pod or services reside.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"defaultSchema": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DefaultSchema define the default schema used to connect to a target Indicates that discovery is disable; cannot be used for prefix based discovery rules",
@@ -1663,6 +1670,13 @@ func schema_config_server_apis_inv_v1alpha1_SchemaSpec(ref common.ReferenceCallb
 						SchemaProps: spec.SchemaProps{
 							Description: "URL specifies the base URL for a given repository",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"credentials": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Credentials defines the name of the secret that holds the credentials to connect to the repo",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2053,6 +2067,12 @@ func schema_config_server_apis_inv_v1alpha1_TargetConnectionProfileSpec(ref comm
 					"useOperationRemove": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"commitCandidate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
 							Format: "",
 						},
 					},

--- a/apis/inv/v1alpha1/schema_types.go
+++ b/apis/inv/v1alpha1/schema_types.go
@@ -37,7 +37,7 @@ type SchemaSpec struct {
 	RepositoryURL string `json:"repoURL" yaml:"repoURL"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="credentials is immutable"
 	// Credentials defines the name of the secret that holds the credentials to connect to the repo
-	Credentials string `json:"credentials" yaml:"credentials"`
+	Credentials string `json:"credentials,omitempty" yaml:"credentials,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="provider is immutable"
 	// Provider specifies the provider of the schema.
 	Provider string `json:"provider" yaml:"provider"`

--- a/artifacts/inv.sdcio.dev_schemas.yaml
+++ b/artifacts/inv.sdcio.dev_schemas.yaml
@@ -153,7 +153,6 @@ spec:
                 - message: version is immutable
                   rule: self == oldSelf
             required:
-            - credentials
             - kind
             - provider
             - ref

--- a/artifacts/inv.sdcio.dev_targetconnectionprofiles.yaml
+++ b/artifacts/inv.sdcio.dev_targetconnectionprofiles.yaml
@@ -39,6 +39,15 @@ spec:
             description: TargetConnectionProfileSpec defines the desired state of
               TargetConnectionProfile
             properties:
+              commitCandidate:
+                default: candidate
+                enum:
+                - candidate
+                - running
+                type: string
+                x-kubernetes-validations:
+                - message: UseOperationRemove is immutable
+                  rule: self == oldSelf
               connectRetry:
                 default: 10s
                 type: string

--- a/artifacts/out/artifacts.yaml
+++ b/artifacts/out/artifacts.yaml
@@ -11,125 +11,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
-  name: targetsyncprofiles.inv.sdcio.dev
-spec:
-  group: inv.sdcio.dev
-  names:
-    categories:
-    - sdc
-    - inv
-    kind: TargetSyncProfile
-    listKind: TargetSyncProfileList
-    plural: targetsyncprofiles
-    singular: targetsyncprofile
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: TargetSyncProfile is the Schema for the TargetSyncProfile API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TargetSyncProfileSpec defines the desired state of TargetSyncProfile
-            properties:
-              buffer:
-                default: 0
-                format: int64
-                type: integer
-                x-kubernetes-validations:
-                - message: buffer is immutable
-                  rule: self == oldSelf
-              sync:
-                items:
-                  description: TargetSyncProfileSync defines the desired state of
-                    TargetSyncProfileSync
-                  properties:
-                    encoding:
-                      default: ASCII
-                      enum:
-                      - unknown
-                      - JSON
-                      - JSON_IETF
-                      - bytes
-                      - protobuf
-                      - ASCII
-                      - config
-                      type: string
-                    interval:
-                      default: 60s
-                      type: string
-                    mode:
-                      enum:
-                      - unknown
-                      - onChange
-                      - sample
-                      - once
-                      type: string
-                    name:
-                      type: string
-                    paths:
-                      items:
-                        type: string
-                      maxItems: 10
-                      type: array
-                    protocol:
-                      default: gnmi
-                      enum:
-                      - unknown
-                      - gnmi
-                      - netconf
-                      - noop
-                      type: string
-                  required:
-                  - mode
-                  - name
-                  - paths
-                  - protocol
-                  type: object
-                maxItems: 10
-                type: array
-                x-kubernetes-validations:
-                - message: sync may only be added
-                  rule: oldSelf.all(x, x in self)
-              validate:
-                default: true
-                type: boolean
-                x-kubernetes-validations:
-                - message: validate is immutable
-                  rule: self == oldSelf
-              workers:
-                default: 10
-                format: int64
-                type: integer
-                x-kubernetes-validations:
-                - message: workers is immutable
-                  rule: self == oldSelf
-            type: object
-            x-kubernetes-validations:
-            - message: sync is required once set
-              rule: '!has(oldSelf.sync) || has(self.sync)'
-        type: object
-    served: true
-    storage: true
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
   name: schemas.inv.sdcio.dev
 spec:
   group: inv.sdcio.dev
@@ -363,6 +244,257 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+  name: targetconnectionprofiles.inv.sdcio.dev
+spec:
+  group: inv.sdcio.dev
+  names:
+    categories:
+    - sdc
+    - inv
+    kind: TargetConnectionProfile
+    listKind: TargetConnectionProfileList
+    plural: targetconnectionprofiles
+    singular: targetconnectionprofile
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetConnectionProfile is the Schema for the TargetConnectionProfile
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetConnectionProfileSpec defines the desired state of
+              TargetConnectionProfile
+            properties:
+              connectRetry:
+                default: 10s
+                type: string
+                x-kubernetes-validations:
+                - message: connectRetry is immutable
+                  rule: self == oldSelf
+              encoding:
+                default: ASCII
+                enum:
+                - unknown
+                - JSON
+                - JSON_IETF
+                - bytes
+                - protobuf
+                - ASCII
+                - config
+                type: string
+                x-kubernetes-validations:
+                - message: encoding is immutable
+                  rule: self == oldSelf
+              includeNS:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: includeNS is immutable
+                  rule: self == oldSelf
+              insecure:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: insecure is immutable
+                  rule: self == oldSelf
+              operationWithNS:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: operationWithNS is immutable
+                  rule: self == oldSelf
+              port:
+                default: 57400
+                description: Port defines the port on which the scan runs
+                type: integer
+                x-kubernetes-validations:
+                - message: port is immutable
+                  rule: self == oldSelf
+              preferredNetconfVersion:
+                default: "1.0"
+                enum:
+                - "1.0"
+                - "1.1"
+                type: string
+                x-kubernetes-validations:
+                - message: preferredNetconfVersion is immutable
+                  rule: self == oldSelf
+              protocol:
+                default: gnmi
+                enum:
+                - unknown
+                - gnmi
+                - netconf
+                - noop
+                type: string
+                x-kubernetes-validations:
+                - message: protocol is immutable
+                  rule: self == oldSelf
+              skipVerify:
+                default: true
+                type: boolean
+                x-kubernetes-validations:
+                - message: skipVerify is immutable
+                  rule: self == oldSelf
+              timeout:
+                default: 10s
+                type: string
+                x-kubernetes-validations:
+                - message: timeout is immutable
+                  rule: self == oldSelf
+              useOperationRemove:
+                default: false
+                type: boolean
+                x-kubernetes-validations:
+                - message: UseOperationRemove is immutable
+                  rule: self == oldSelf
+            required:
+            - port
+            - protocol
+            type: object
+        type: object
+    served: true
+    storage: true
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.1
+  name: targetsyncprofiles.inv.sdcio.dev
+spec:
+  group: inv.sdcio.dev
+  names:
+    categories:
+    - sdc
+    - inv
+    kind: TargetSyncProfile
+    listKind: TargetSyncProfileList
+    plural: targetsyncprofiles
+    singular: targetsyncprofile
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetSyncProfile is the Schema for the TargetSyncProfile API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetSyncProfileSpec defines the desired state of TargetSyncProfile
+            properties:
+              buffer:
+                default: 0
+                format: int64
+                type: integer
+                x-kubernetes-validations:
+                - message: buffer is immutable
+                  rule: self == oldSelf
+              sync:
+                items:
+                  description: TargetSyncProfileSync defines the desired state of
+                    TargetSyncProfileSync
+                  properties:
+                    encoding:
+                      default: ASCII
+                      enum:
+                      - unknown
+                      - JSON
+                      - JSON_IETF
+                      - bytes
+                      - protobuf
+                      - ASCII
+                      - config
+                      type: string
+                    interval:
+                      default: 60s
+                      type: string
+                    mode:
+                      enum:
+                      - unknown
+                      - onChange
+                      - sample
+                      - once
+                      type: string
+                    name:
+                      type: string
+                    paths:
+                      items:
+                        type: string
+                      maxItems: 10
+                      type: array
+                    protocol:
+                      default: gnmi
+                      enum:
+                      - unknown
+                      - gnmi
+                      - netconf
+                      - noop
+                      type: string
+                  required:
+                  - mode
+                  - name
+                  - paths
+                  - protocol
+                  type: object
+                maxItems: 10
+                type: array
+                x-kubernetes-validations:
+                - message: sync may only be added
+                  rule: oldSelf.all(x, x in self)
+              validate:
+                default: true
+                type: boolean
+                x-kubernetes-validations:
+                - message: validate is immutable
+                  rule: self == oldSelf
+              workers:
+                default: 10
+                format: int64
+                type: integer
+                x-kubernetes-validations:
+                - message: workers is immutable
+                  rule: self == oldSelf
+            type: object
+            x-kubernetes-validations:
+            - message: sync is required once set
+              rule: '!has(oldSelf.sync) || has(self.sync)'
+        type: object
+    served: true
+    storage: true
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: targets.inv.sdcio.dev
 spec:
   group: inv.sdcio.dev
@@ -576,138 +708,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
-  name: targetconnectionprofiles.inv.sdcio.dev
-spec:
-  group: inv.sdcio.dev
-  names:
-    categories:
-    - sdc
-    - inv
-    kind: TargetConnectionProfile
-    listKind: TargetConnectionProfileList
-    plural: targetconnectionprofiles
-    singular: targetconnectionprofile
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: TargetConnectionProfile is the Schema for the TargetConnectionProfile
-          API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TargetConnectionProfileSpec defines the desired state of
-              TargetConnectionProfile
-            properties:
-              connectRetry:
-                default: 10s
-                type: string
-                x-kubernetes-validations:
-                - message: connectRetry is immutable
-                  rule: self == oldSelf
-              encoding:
-                default: ASCII
-                enum:
-                - unknown
-                - JSON
-                - JSON_IETF
-                - bytes
-                - protobuf
-                - ASCII
-                - config
-                type: string
-                x-kubernetes-validations:
-                - message: encoding is immutable
-                  rule: self == oldSelf
-              includeNS:
-                default: false
-                type: boolean
-                x-kubernetes-validations:
-                - message: includeNS is immutable
-                  rule: self == oldSelf
-              insecure:
-                default: false
-                type: boolean
-                x-kubernetes-validations:
-                - message: insecure is immutable
-                  rule: self == oldSelf
-              operationWithNS:
-                default: false
-                type: boolean
-                x-kubernetes-validations:
-                - message: operationWithNS is immutable
-                  rule: self == oldSelf
-              port:
-                default: 57400
-                description: Port defines the port on which the scan runs
-                type: integer
-                x-kubernetes-validations:
-                - message: port is immutable
-                  rule: self == oldSelf
-              preferredNetconfVersion:
-                default: "1.0"
-                enum:
-                - "1.0"
-                - "1.1"
-                type: string
-                x-kubernetes-validations:
-                - message: preferredNetconfVersion is immutable
-                  rule: self == oldSelf
-              protocol:
-                default: gnmi
-                enum:
-                - unknown
-                - gnmi
-                - netconf
-                - noop
-                type: string
-                x-kubernetes-validations:
-                - message: protocol is immutable
-                  rule: self == oldSelf
-              skipVerify:
-                default: true
-                type: boolean
-                x-kubernetes-validations:
-                - message: skipVerify is immutable
-                  rule: self == oldSelf
-              timeout:
-                default: 10s
-                type: string
-                x-kubernetes-validations:
-                - message: timeout is immutable
-                  rule: self == oldSelf
-              useOperationRemove:
-                default: false
-                type: boolean
-                x-kubernetes-validations:
-                - message: UseOperationRemove is immutable
-                  rule: self == oldSelf
-            required:
-            - port
-            - protocol
-            type: object
-        type: object
-    served: true
-    storage: true
-
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.1
   name: discoveryrules.inv.sdcio.dev
 spec:
   group: inv.sdcio.dev
@@ -803,6 +803,11 @@ spec:
                 - connectionProfiles
                 - credentials
                 type: object
+              domainName:
+                description: DomainName defines the domain name of the cluster, used
+                  by pod or svc discovery to identify the domain name in the l8s cluster
+                  where the pod or services reside.
+                type: string
               period:
                 description: Period defines the wait period between discovery rule
                   runs


### PR DESCRIPTION
Fix

Why?

credentials should be optional in a schema CRD. Typically used to access private repos