### PR TITLE
fix: tree pull should check on already up to date

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -190,20 +190,18 @@ func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
 		log.Debug("pulling latest repo data")
 		// execute the pull
 		// execute the checkout
-		if err := g.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
+		switch err := g.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
 			return tree.Pull(&gogit.PullOptions{
 				Depth:        1,
 				SingleBranch: true,
 				Force:        true,
 				Auth:         auth,
 			})
-		}); err != nil {
-			return err
-		}
-
-		if err == gogit.NoErrAlreadyUpToDate {
-			log.Info("git repository up to date")
+		}); err {
+		case nil, gogit.NoErrAlreadyUpToDate:
 			err = nil
+		default:
+			return err
 		}
 	}
 


### PR DESCRIPTION
updated logic to handle case where a tree pull is already up to date.

Release Note:

When using multiple schema's in the same repo a tree Pull could return error already up to date. This is not handled properly resulting in the fact that if you load a 2nd schema from the same repo the schema would never load.