### PR TITLE
updated schema error handling to retry or not based on error indication

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -30,6 +30,8 @@ import (
 	"github.com/henderiw/logger/log"
 	"github.com/sdcio/config-server/pkg/git/auth"
 	"k8s.io/apimachinery/pkg/types"
+
+	myerror "github.com/sdcio/config-server/pkg/reconcilers/error"
 )
 
 type GoGit struct {
@@ -55,17 +57,17 @@ func NewGoGit(gitRepo GitRepo, secret types.NamespacedName, credentialResolver a
 
 // Clone takes the given GitRepo reference and clones the repo
 // with its internal implementation.
-func (g *GoGit) Clone(ctx context.Context) error {
+func (r *GoGit) Clone(ctx context.Context) error {
 	log := log.FromContext(ctx)
 	// if the directory is not present
-	if s, err := os.Stat(g.gitRepo.GetLocalPath()); os.IsNotExist(err) {
+	if s, err := os.Stat(r.gitRepo.GetLocalPath()); os.IsNotExist(err) {
 		log.Info("cloning a new local repository")
-		return g.cloneNonExisting(ctx)
+		return r.cloneNonExisting(ctx)
 	} else if s.IsDir() {
 		log.Info("cloning an existing local repository")
-		return g.cloneExistingRepo(ctx)
+		return r.cloneExistingRepo(ctx)
 	}
-	return fmt.Errorf("error %q exists already but is a file", g.gitRepo.GetName())
+	return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("repo %q exists, but is a file", r.gitRepo.GetName())}
 }
 
 func (g *GoGit) getDefaultBranch(ctx context.Context) (string, error) {
@@ -83,7 +85,7 @@ func (g *GoGit) getDefaultBranch(ctx context.Context) (string, error) {
 		})
 		return err
 	}); err != nil {
-		return "", err
+		return "", &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get default branch", OrigError: err}
 	}
 
 	for _, ref := range refs {
@@ -92,7 +94,7 @@ func (g *GoGit) getDefaultBranch(ctx context.Context) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("unable to determine default branch for %q", g.gitRepo.GetCloneURL().String())
+	return "", &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("unable to determine default branch for %q", g.gitRepo.GetCloneURL().String())}
 }
 
 func (g *GoGit) openRepo(_ context.Context) error {
@@ -101,37 +103,38 @@ func (g *GoGit) openRepo(_ context.Context) error {
 	// load the git repository
 	g.r, err = gogit.PlainOpen(g.gitRepo.GetLocalPath())
 	if err != nil {
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot open repo", OrigError: err}
 	}
 	return nil
 }
 
-func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
+func (r *GoGit) cloneExistingRepo(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	log.Info("loading git", "repo", g.gitRepo.GetLocalPath())
+	log.Info("loading git", "repo", r.gitRepo.GetLocalPath())
 
 	// open the existing repo
-	err := g.openRepo(ctx)
+	err := r.openRepo(ctx)
 	if err != nil {
 		return err
 	}
 
 	// loading remote
-	remote, err := g.r.Remote("origin")
+	remote, err := r.r.Remote("origin")
 	if err != nil {
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get remote from repo", OrigError: err}
 	}
 
 	// checking that the configured remote equals the provided remote
-	if remote.Config().URLs[0] != g.gitRepo.GetCloneURL().String() {
-		return fmt.Errorf("repository url of %q differs (%q) from the provided url (%q). stopping",
-			g.gitRepo.GetName(), remote.Config().URLs[0], g.gitRepo.GetCloneURL().String())
+	if remote.Config().URLs[0] != r.gitRepo.GetCloneURL().String() {
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("repository url of %q differs (%q) from the provided url (%q). stopping",
+			r.gitRepo.GetName(), remote.Config().URLs[0], r.gitRepo.GetCloneURL().String())}
+
 	}
 
 	// get the worktree reference
-	tree, err := g.r.Worktree()
+	tree, err := r.r.Worktree()
 	if err != nil {
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get worktree", OrigError: err}
 	}
 
 	// prepare the checkout options
@@ -140,8 +143,8 @@ func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
 	// resolve the branch
 	// the branch ref from the URL might be empty -> ""
 	// then we need to figure out whats the default branch main / master / sth. else.
-	branch := g.gitRepo.GetBranch()
-	tag := g.gitRepo.GetTag()
+	branch := r.gitRepo.GetBranch()
+	tag := r.gitRepo.GetTag()
 	isTag := false
 	if branch != "" {
 		checkoutOpts.Branch = plumbing.NewBranchReferenceName(branch)
@@ -149,25 +152,25 @@ func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
 		checkoutOpts.Branch = plumbing.NewTagReferenceName(tag)
 		isTag = true
 	} else {
-		log.Info("default branch not set. determining it")
-		branch, err = g.getDefaultBranch(ctx)
+		log.Debug("default branch not set. determining it")
+		branch, err = r.getDefaultBranch(ctx)
 		if err != nil {
 			return err
 		}
-		log.Info("default", "branch", branch)
+		log.Debug("default", "branch", branch)
 	}
 
 	// check if the branch already exists locally.
 	// if not fetch it and check it out.
-	if _, err = g.r.Reference(plumbing.NewBranchReferenceName(branch), false); !isTag && err != nil {
-		err = g.fetchNonExistingBranch(ctx, branch)
+	if _, err = r.r.Reference(plumbing.NewBranchReferenceName(branch), false); !isTag && err != nil {
+		err = r.fetchNonExistingBranch(ctx, branch)
 		if err != nil {
-			return err
+			return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get reference", OrigError: err}
 		}
 
-		ref, err := g.r.Reference(plumbing.NewRemoteReferenceName("origin", branch), true)
+		ref, err := r.r.Reference(plumbing.NewRemoteReferenceName("origin", branch), true)
 		if err != nil {
-			return err
+			return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get remote reference", OrigError: err}
 		}
 
 		checkoutOpts.Hash = ref.Hash()
@@ -175,22 +178,22 @@ func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
 	}
 
 	if isTag {
-		log.Info("checking out", "tag", tag)
+		log.Debug("checking out", "tag", tag)
 	} else {
-		log.Info("checking out", "branch", branch)
+		log.Debug("checking out", "branch", branch)
 	}
 
 	// execute the checkout
 	err = tree.Checkout(checkoutOpts)
 	if err != nil {
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot checkout tree", OrigError: err}
 	}
 
 	if !isTag {
 		log.Debug("pulling latest repo data")
 		// execute the pull
 		// execute the checkout
-		switch err := g.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
+		switch err := r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
 			return tree.Pull(&gogit.PullOptions{
 				Depth:        1,
 				SingleBranch: true,
@@ -204,15 +207,14 @@ func (g *GoGit) cloneExistingRepo(ctx context.Context) error {
 			return err
 		}
 	}
-
 	return err
 }
 
-func (g *GoGit) fetchNonExistingBranch(ctx context.Context, branch string) error {
+func (r *GoGit) fetchNonExistingBranch(ctx context.Context, branch string) error {
 	// init the remote
-	remote, err := g.r.Remote("origin")
+	remote, err := r.r.Remote("origin")
 	if err != nil {
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot get remote from repo", OrigError: err}
 	}
 
 	// build the RefSpec, that wires the remote to the locla branch
@@ -221,7 +223,7 @@ func (g *GoGit) fetchNonExistingBranch(ctx context.Context, branch string) error
 	refSpec := config.RefSpec(fmt.Sprintf("+%s:%s", localRef, remoteRef))
 
 	// execute the fetch
-	switch err := g.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
+	switch err := r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
 		return remote.Fetch(&gogit.FetchOptions{
 			Depth:    1,
 			RefSpecs: []config.RefSpec{refSpec},
@@ -230,35 +232,35 @@ func (g *GoGit) fetchNonExistingBranch(ctx context.Context, branch string) error
 	}); err {
 	case nil, gogit.NoErrAlreadyUpToDate:
 	default:
-		return err
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot fetch repo for branch that does not exist", OrigError: err}
 	}
 
 	// make sure the branch is also showing up in .git/config
-	err = g.r.CreateBranch(&config.Branch{
+	err = r.r.CreateBranch(&config.Branch{
 		Name:   branch,
 		Remote: "origin",
 		Merge:  localRef,
 	})
 
-	return err
+	return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot create branch", OrigError: err}
 }
 
-func (g *GoGit) cloneNonExisting(ctx context.Context) error {
+func (r *GoGit) cloneNonExisting(ctx context.Context) error {
 	var err error
 	// init clone options
 	co := &gogit.CloneOptions{
 		Depth:        1,
-		URL:          g.gitRepo.GetCloneURL().String(),
+		URL:          r.gitRepo.GetCloneURL().String(),
 		SingleBranch: true,
 	}
 
 	// set brach reference if set
-	if g.gitRepo.GetBranch() != "" {
-		co.ReferenceName = plumbing.NewBranchReferenceName(g.gitRepo.GetBranch())
-	} else if g.gitRepo.GetTag() != "" {
-		co.ReferenceName = plumbing.NewTagReferenceName(g.gitRepo.GetTag())
+	if r.gitRepo.GetBranch() != "" {
+		co.ReferenceName = plumbing.NewBranchReferenceName(r.gitRepo.GetBranch())
+	} else if r.gitRepo.GetTag() != "" {
+		co.ReferenceName = plumbing.NewTagReferenceName(r.gitRepo.GetTag())
 	} else {
-		branchName, err := g.getDefaultBranch(ctx)
+		branchName, err := r.getDefaultBranch(ctx)
 		if err != nil {
 			return err
 		}
@@ -266,9 +268,9 @@ func (g *GoGit) cloneNonExisting(ctx context.Context) error {
 	}
 
 	// perform clone
-	return g.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
+	return r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
 		co.Auth = auth
-		g.r, err = gogit.PlainClone(g.gitRepo.GetLocalPath(), false, co)
+		r.r, err = gogit.PlainClone(r.gitRepo.GetLocalPath(), false, co)
 		return err
 	})
 }
@@ -285,20 +287,23 @@ func (r *GoGit) doGitWithAuth(ctx context.Context, op func(transport.AuthMethod)
 	log := log.FromContext(ctx)
 	auth, err := r.getAuthMethod(ctx, false)
 	if err != nil {
-		return fmt.Errorf("failed to obtain git credentials: %w", err)
+		return err
 	}
 	err = op(auth)
 	if err != nil {
 		if !errors.Is(err, transport.ErrAuthenticationRequired) {
-			return err
+			return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "authentication failed", OrigError: err}
 		}
 		log.Info("Authentication failed. Trying to refresh credentials")
 		// TODO: Consider having some kind of backoff here.
 		auth, err := r.getAuthMethod(ctx, true)
 		if err != nil {
-			return fmt.Errorf("failed to obtain git credentials: %w", err)
+			return err
 		}
-		return op(auth)
+		err = op(auth)
+		if err != nil {
+			return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "authentication failed", OrigError: err}
+		}
 	}
 	return nil
 }
@@ -307,7 +312,6 @@ func (r *GoGit) doGitWithAuth(ctx context.Context, op func(transport.AuthMethod)
 // credentials between calls and refresh credentials when the tokens have expired.
 func (r *GoGit) getAuthMethod(ctx context.Context, forceRefresh bool) (transport.AuthMethod, error) {
 	// If no secret is provided, we try without any auth.
-
 	log := log.FromContext(ctx)
 	log.Info("getAuthMethod", "secret", r.secret, "credential", r.credential)
 	if r.secret.Name == "" {
@@ -316,7 +320,7 @@ func (r *GoGit) getAuthMethod(ctx context.Context, forceRefresh bool) (transport
 
 	if r.credential == nil || !r.credential.Valid() || forceRefresh {
 		if cred, err := r.credentialResolver.ResolveCredential(ctx, r.secret); err != nil {
-			return nil, fmt.Errorf("failed to obtain credential from secret %s/%s: %w", "", "", err)
+			return nil, &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: "cannot obtain credentials", OrigError: err}
 		} else {
 			r.credential = cred
 		}

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -17,7 +17,10 @@ limitations under the License.
 package git
 
 import (
+	"fmt"
 	"net/url"
+
+	myerror "github.com/sdcio/config-server/pkg/reconcilers/error"
 )
 
 // GitRepoStruct is a struct that contains all the fields
@@ -88,7 +91,7 @@ func NewRepo(urlPath string) (GitRepo, error) {
 
 	u, err := url.Parse(urlPath)
 	if err != nil {
-		return nil, err
+		return nil, &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("cannot parse urlPath: %s", urlPath), OrigError: err}
 	}
 
 	r = &GitRepoStruct{

--- a/pkg/reconcilers/error/error.go
+++ b/pkg/reconcilers/error/error.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 Nokia.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package error
+
+import "fmt"
+
+type ErrorType string
+
+const (
+	RecoverableErrorType    ErrorType = "recoverable"
+	NonRecoverableErrorType ErrorType = "nonrecoverable"
+)
+
+type MyError struct {
+	Type      ErrorType
+	Message   string
+	OrigError error
+}
+
+func (r *MyError) Error() string {
+	if r.OrigError != nil {
+		return fmt.Sprintf("%s, err: %s", r.Message, r.OrigError.Error())
+	}
+	return r.Message
+}

--- a/pkg/schema/loader.go
+++ b/pkg/schema/loader.go
@@ -78,7 +78,7 @@ func (r *Loader) AddRef(ctx context.Context, spec *invv1alpha1.SchemaSpec) {
 func (r *Loader) DelRef(ctx context.Context, key string) error {
 	ref, dirExists, err := r.GetRef(ctx, key)
 	if err != nil {
-		// ref does not exist
+		// ref does not exist -> we dont return an error
 		return nil
 	}
 	if dirExists {
@@ -96,7 +96,7 @@ func (r *Loader) del(key string) {
 	delete(r.schemas, key)
 }
 
-// GetRef return an error of the ref does not exist
+// GetRef return an error if the ref does not exist
 // If the ref exists the ref is retrieved with an inidcation if the base provider schema version dir exists
 func (r *Loader) GetRef(ctx context.Context, key string) (*invv1alpha1.SchemaSpec, bool, error) {
 	ref, exists := r.get(key)

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	myerror "github.com/sdcio/config-server/pkg/reconcilers/error"
 )
 
 // FileExists returns true if a file referenced by filename exists & accessible.
@@ -51,7 +52,7 @@ func DirExists(filename string) bool {
 func CreateDirectory(path string, perm os.FileMode) error {
 	err := os.MkdirAll(path, perm)
 	if err != nil {
-		return fmt.Errorf("error while creating a directory path %v: %v", path, err)
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("cannot create directory path %s", path), OrigError: err}
 	}
 	return nil
 }
@@ -60,14 +61,17 @@ func ErrNotIsSubfolder(base, specific string) error {
 	var err error
 	rel, err := filepath.Rel(base, specific)
 	if err != nil {
-		return err
+		 return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("cannot create relative path from base %s and specific %s", base, specific), OrigError: err}
 	}
 	if strings.HasPrefix(rel, "../") {
-		err = fmt.Errorf("folder %q is not located within the defined base folder %q", specific, base)
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("folder %q is not located within the defined base folder %q", specific, base)}
 	}
 	return err
 }
 
 func RemoveDirectory(path string) error {
-	return os.RemoveAll(path)
+	if err := os.RemoveAll(path); err != nil {
+		return &myerror.MyError{Type: myerror.NonRecoverableErrorType, Message: fmt.Sprintf("cannot delete directory path %s", path), OrigError: err}
+	}
+	return nil
 }


### PR DESCRIPTION
updated error handling in schema loading to indicate if the error is recoverable or not. If not we don't retry.
E.g. when an auth failure is happening it locks out the git user from logging in.