### PR TITLE
aligned encodings in the connection/sync profile with gnmi

### DIFF
--- a/apis/inv/v1alpha1/targetconnprofile_types.go
+++ b/apis/inv/v1alpha1/targetconnprofile_types.go
@@ -26,11 +26,11 @@ import (
 type Encoding string
 
 const (
-	Encoding_Unknown   Encoding = "unknown"
+	Encoding_Unknown   Encoding = "UNKNOWN"
 	Encoding_JSON      Encoding = "JSON"
 	Encoding_JSON_IETF Encoding = "JSON_IETF"
-	Encoding_Bytes     Encoding = "bytes"
-	Encoding_Protobuf  Encoding = "protobuf"
+	Encoding_Bytes     Encoding = "BYTES"
+	Encoding_Protobuf  Encoding = "PROTO"
 	Encoding_Ascii     Encoding = "ASCII"
 	Encoding_Config    Encoding = "config"
 )
@@ -69,7 +69,7 @@ type TargetConnectionProfileSpec struct {
 	// Port defines the port on which the scan runs
 	Port uint `json:"port" yaml:"port"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="encoding is immutable"
-	// +kubebuilder:validation:Enum=unknown;JSON;JSON_IETF;bytes;protobuf;ASCII;config;
+	// +kubebuilder:validation:Enum=UNKNOWN;JSON;JSON_IETF;BYTES;PROTO;ASCII;CONFIG;
 	// +kubebuilder:default:="ASCII"
 	Encoding Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="preferredNetconfVersion is immutable"

--- a/apis/inv/v1alpha1/targetsyncprofile_types.go
+++ b/apis/inv/v1alpha1/targetsyncprofile_types.go
@@ -61,7 +61,7 @@ type TargetSyncProfileSync struct {
 	Paths []string `json:"paths" yaml:"paths"`
 	//+kubebuilder:validation:Enum=unknown;onChange;sample;once;get;
 	Mode SyncMode `json:"mode" yaml:"mode"`
-	// +kubebuilder:validation:Enum=unknown;JSON;JSON_IETF;bytes;protobuf;ASCII;config;
+	// +kubebuilder:validation:Enum=UNKNOWN;JSON;JSON_IETF;BYTES;PROTO;ASCII;CONFIG;
 	// +kubebuilder:default:="ASCII"
 	Encoding Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 	// +kubebuilder:default:="60s"

--- a/artifacts/inv.sdcio.dev_targetconnectionprofiles.yaml
+++ b/artifacts/inv.sdcio.dev_targetconnectionprofiles.yaml
@@ -57,13 +57,13 @@ spec:
               encoding:
                 default: ASCII
                 enum:
-                - unknown
+                - UNKNOWN
                 - JSON
                 - JSON_IETF
-                - bytes
-                - protobuf
+                - BYTES
+                - PROTO
                 - ASCII
-                - config
+                - CONFIG
                 type: string
                 x-kubernetes-validations:
                 - message: encoding is immutable

--- a/artifacts/inv.sdcio.dev_targetsyncprofiles.yaml
+++ b/artifacts/inv.sdcio.dev_targetsyncprofiles.yaml
@@ -52,13 +52,13 @@ spec:
                     encoding:
                       default: ASCII
                       enum:
-                      - unknown
+                      - UNKNOWN
                       - JSON
                       - JSON_IETF
-                      - bytes
-                      - protobuf
+                      - BYTES
+                      - PROTO
                       - ASCII
-                      - config
+                      - CONFIG
                       type: string
                     interval:
                       default: 60s


### PR DESCRIPTION
make them all uppercase and aligned with gnmi