### PR TITLE
Changed the data-service targetPort to a named port

### DIFF
--- a/artifacts/deployment.yaml
+++ b/artifacts/deployment.yaml
@@ -91,6 +91,9 @@ spec:
         - /app/data-server
         args:
         - "--config=/config/data-server.yaml"
+        ports:
+        - name: data-service
+          containerPort: 56000
         volumeMounts:
         - name: data-server-config
           mountPath: /config

--- a/artifacts/service-data-server.yaml
+++ b/artifacts/service-data-server.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/name: config-server
 spec:
   ports:
-  - port: 56000
+  - name: data-service
+    port: 56000
     protocol: TCP
-    targetPort: 56000
+    targetPort: data-service
   selector:
     sdcio.dev/data-server: "true"


### PR DESCRIPTION
Using named Ports allows for easier debugging using Telepresence because no init-container has to be injected. The init-container led to failures in our tests. See: https://www.telepresence.io/docs/troubleshooting/#injected-init-container-doesnt-function-properly
