### PR TITLE
added table name with resource

### DIFF
--- a/apis/config/config_resource.go
+++ b/apis/config/config_resource.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/henderiw/apiserver-builder/pkg/builder/resource"
 	"github.com/henderiw/apiserver-store/pkg/generic/registry"
@@ -117,7 +118,7 @@ func (r *Config) IsEqual(ctx context.Context, obj, old runtime.Object) bool {
 		return false
 	}
 	// if equal we also test the spec
-	return apiequality.Semantic.DeepEqual(oldobj.Spec, newobj.Spec) 
+	return apiequality.Semantic.DeepEqual(oldobj.Spec, newobj.Spec)
 }
 
 // GetStatus return the resource.StatusSubResource interface
@@ -180,9 +181,10 @@ func (r *Config) TableConvertor() func(gr schema.GroupResource) rest.TableConver
 					return nil
 				}
 				return []interface{}{
-					config.Name,
+					fmt.Sprintf("%s.%s/%s", strings.ToLower(ConfigKind), GroupName, config.Name),
 					config.GetCondition(condition.ConditionTypeReady).Status,
 					config.GetCondition(condition.ConditionTypeReady).Reason,
+					config.Spec.Priority,
 					config.GetTarget(),
 					config.GetLastKnownGoodSchema().FileString(),
 				}
@@ -191,6 +193,7 @@ func (r *Config) TableConvertor() func(gr schema.GroupResource) rest.TableConver
 				{Name: "Name", Type: "string"},
 				{Name: "Ready", Type: "string"},
 				{Name: "Reason", Type: "string"},
+				{Name: "Priority", Type: "integer"},
 				{Name: "Target", Type: "string"},
 				{Name: "Schema", Type: "string"},
 			},

--- a/apis/config/configset_resource.go
+++ b/apis/config/configset_resource.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/henderiw/apiserver-builder/pkg/builder/resource"
 	"github.com/henderiw/apiserver-store/pkg/generic/registry"
@@ -124,7 +125,7 @@ func (r *ConfigSet) GetStatus() resource.StatusSubResource {
 
 // IsStatusEqual returns a bool indicating if the status of both resources is equal or not
 func (r *ConfigSet) IsStatusEqual(ctx context.Context, obj, old runtime.Object) bool {
-	
+
 	log := log.FromContext(ctx)
 	newobj := obj.(*ConfigSet)
 	oldobj := old.(*ConfigSet)
@@ -180,7 +181,7 @@ func (r *ConfigSet) TableConvertor() func(gr schema.GroupResource) rest.TableCon
 					return nil
 				}
 				return []interface{}{
-					configset.Name,
+					fmt.Sprintf("%s.%s/%s", strings.ToLower(ConfigSetKind), GroupName, configset.Name),
 					configset.GetCondition(condition.ConditionTypeReady).Status,
 					len(configset.Status.Targets),
 				}

--- a/apis/config/running_config_resource.go
+++ b/apis/config/running_config_resource.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/henderiw/apiserver-builder/pkg/builder/resource"
 	"github.com/henderiw/apiserver-store/pkg/generic/registry"
@@ -128,7 +129,7 @@ func (r *RunningConfig) TableConvertor() func(gr schema.GroupResource) rest.Tabl
 					return nil
 				}
 				return []interface{}{
-					RunningConfig.Name,
+					fmt.Sprintf("%s.%s/%s", strings.ToLower(RunningConfigKind), GroupName, RunningConfig.Name),
 				}
 			},
 			[]metav1.TableColumnDefinition{

--- a/apis/config/unmanaged_config_resource.go
+++ b/apis/config/unmanaged_config_resource.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/henderiw/apiserver-builder/pkg/builder/resource"
 	"github.com/henderiw/apiserver-store/pkg/generic/registry"
@@ -176,7 +177,7 @@ func (r *UnManagedConfig) TableConvertor() func(gr schema.GroupResource) rest.Ta
 					return nil
 				}
 				return []interface{}{
-					UnManagedConfig.Name,
+					fmt.Sprintf("%s.%s/%s", strings.ToLower(UnManagedConfigKind), GroupName, UnManagedConfig.Name),
 					len(UnManagedConfig.Status.Deviations),
 				}
 			},

--- a/docs/0.0.46.md
+++ b/docs/0.0.46.md
@@ -1,0 +1,12 @@
+# Release 0.0.45
+
+[ChangeLog](https://github.com/sdcio/config-server/releases)
+
+## better output for k get sdc
+
+resource from the aggregated api server were not prefixed with the kind/group and this was different from how crd resources were presented. In this release we align them such that a user does not see a difference in the table representation.
+
+## add priority of a config resource table output
+
+in the table output we now include the priority
+


### PR DESCRIPTION
added better table names including resource/group as is done by crds

this should make k get sdc look better

(.venv) global % kc get sdc -A
NAMESPACE   NAME                             READY   REASON   TARGET              SCHEMA
default     global-srl-nokia-acl-srl-leaf1   False            default/srl-leaf1
default     global-srl-nokia-acl-srl-leaf2   False            default/srl-leaf2
default     global-srl-nokia-acl-srl-spine   False            default/srl-spine
 
NAMESPACE   NAME                   READY   TARGETS
default     global-srl-nokia-acl   False   0
 
NAMESPACE   NAME
default     srl-leaf1
default     srl-spine
default     srl-leaf2
 
NAMESPACE   NAME        DEVIATIONS
default     srl-leaf1   585
default     srl-leaf2   585
default     srl-spine   587
 
NAMESPACE   NAME                                              READY
default     discoveryrule.inv.sdcio.dev/dc1-leaf-srl-nokia    True
default     discoveryrule.inv.sdcio.dev/dc1-spine-srl-nokia   True
 
NAMESPACE   NAME                                               READY   PROVIDER              VERSION   URL                                            REF
default     schema.inv.sdcio.dev/srl.nokia.sdcio.dev-23.10.6   True    srl.nokia.sdcio.dev   23.10.6   https://github.com/nokia/srlinux-yang-models   v23.10.6
default     schema.inv.sdcio.dev/srl.nokia.sdcio.dev-24.10.1   True    srl.nokia.sdcio.dev   24.10.1   https://github.com/nokia/srlinux-yang-models   v24.10.1
 
NAMESPACE   NAME                                                    PROTOCOL   PORT    ENCODING    INSECURE   SKIPVERIFY
default     targetconnectionprofile.inv.sdcio.dev/gnmi-skipverify   gnmi       57400   JSON_IETF   false      true
 
NAMESPACE   NAME                             READY   REASON   PROVIDER              ADDRESS                                     PLATFORM       SERIALNUMBER     MACADDRESS
default     target.inv.sdcio.dev/srl-leaf1   True             srl.nokia.sdcio.dev   srl-leaf1.c9s-leafspine.svc.cluster.local   7220 IXR-D2L   Sim Serial No.   1A:C5:00:FF:00:00
default     target.inv.sdcio.dev/srl-leaf2   True             srl.nokia.sdcio.dev   srl-leaf2.c9s-leafspine.svc.cluster.local   7220 IXR-D2L   Sim Serial No.   1A:88:00:FF:00:00
default     target.inv.sdcio.dev/srl-spine   True             srl.nokia.sdcio.dev   srl-spine.c9s-leafspine.svc.cluster.local   7220 IXR-D3L   Sim Serial No.   1A:5D:00:FF:00:00
 
NAMESPACE   NAME                                       PROTOCOL   PORT    ENCODING    MODE   INTERVAL
default     targetsyncprofile.inv.sdcio.dev/gnmi-get   gnmi       57400   JSON_IETF   get    30s