### PR TITLE
Add NetworkPolicy to allow ingress traffic to apiserver extension

### DIFF
--- a/artifacts/allow-apiserver-extension-traffic.yaml
+++ b/artifacts/allow-apiserver-extension-traffic.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: config-server
+  name: allow-traffic-to-apiserver-extension
+  namespace: network-system
+spec:
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0 # Can be made more restrictive by only allowing from control plane node IPs
+      ports:
+        - port: api-service
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: config-server
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
The addition of a NetworkPolicy for the metrics endpoint blacklisted all other ingress to the config-server, including the apiserver extension.
This PR adds a policy to allow from all CIDRs to the apiserver running on port 6443 in the config-server pod.
As we cannot specify a label selector for the kubernetes API Server, all IPs must be allowed in the generic case, but this can be made more restrictive by changing the allowed IPs to be those of the control plane nodes.