### PR TITLE
reset unmanaged deviations

### DIFF
--- a/pkg/target/deviation_watcher.go
+++ b/pkg/target/deviation_watcher.go
@@ -128,6 +128,9 @@ func (r *DeviationWatcher) start(ctx context.Context) {
 				continue
 			}
 			deviations = make(map[string][]*sdcpb.WatchDeviationResponse, 0)
+			// set the unmanaged devidations to 0 upon start; if no unmanaged deviations are reported
+			// this will reset the unmanaged deviations.
+			deviations[unManagedConfigDeviation] = make([]*sdcpb.WatchDeviationResponse, 0)
 			started = true
 		case sdcpb.DeviationEvent_UPDATE:
 			if !started {


### PR DESCRIPTION
when deviations are reported and no deviations exists, we should imply an empty list.
for unmanaged deviations we can initialize the list to 0 upon start. For managed intents this needs to be handled differently.