### PR TITLE
fix delete handling on datastore unavailability + avoid recovering when no spec/status changed.

### DIFF
--- a/apis/condition/condition.go
+++ b/apis/condition/condition.go
@@ -115,14 +115,11 @@ func (r *ConditionedStatus) SetConditions(c ...Condition) {
 			if existing.Type != new.Type {
 				continue
 			}
-
-			if existing.Equal(new) {
-				exists = true
-				continue
-			}
-
-			r.Conditions[i] = new
 			exists = true
+			if existing.Equal(new) {
+				break
+			}
+			r.Conditions[i] = new
 		}
 		if !exists {
 			r.Conditions = append(r.Conditions, new)

--- a/apis/condition/v1alpha1/condition.go
+++ b/apis/condition/v1alpha1/condition.go
@@ -116,13 +116,11 @@ func (r *ConditionedStatus) SetConditions(c ...Condition) {
 				continue
 			}
 
-			if existing.Equal(new) {
-				exists = true
-				continue
-			}
-
-			r.Conditions[i] = new
 			exists = true
+			if existing.Equal(new) {
+				break
+			}
+			r.Conditions[i] = new
 		}
 		if !exists {
 			r.Conditions = append(r.Conditions, new)

--- a/apis/config/configset_resource.go
+++ b/apis/config/configset_resource.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/henderiw/apiserver-builder/pkg/builder/resource"
 	"github.com/henderiw/apiserver-store/pkg/generic/registry"
-	"github.com/henderiw/logger/log"
 	"github.com/sdcio/config-server/apis/condition"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -125,11 +124,8 @@ func (r *ConfigSet) GetStatus() resource.StatusSubResource {
 
 // IsStatusEqual returns a bool indicating if the status of both resources is equal or not
 func (r *ConfigSet) IsStatusEqual(ctx context.Context, obj, old runtime.Object) bool {
-
-	log := log.FromContext(ctx)
 	newobj := obj.(*ConfigSet)
 	oldobj := old.(*ConfigSet)
-	log.Info("IsStatusEqual configset", "old status", oldobj.Status, "newstatus ", newobj.Status)
 	return apiequality.Semantic.DeepEqual(oldobj.Status, newobj.Status)
 }
 

--- a/apis/inv/v1alpha1/target_helpers.go
+++ b/apis/inv/v1alpha1/target_helpers.go
@@ -47,19 +47,19 @@ func (r *Target) SetOverallStatus(target *Target) {
 	msg := "target ready"
 	if ready && !target.GetCondition(ConditionTypeDiscoveryReady).IsTrue() {
 		ready = false
-		msg = fmt.Sprintf("discovery not ready: %s", target.GetCondition(ConditionTypeDiscoveryReady).Message)
+		msg = fmt.Sprintf("discovery not ready")// target.GetCondition(ConditionTypeDiscoveryReady).Message)
 	}
 	if ready && !target.GetCondition(ConditionTypeDatastoreReady).IsTrue() {
 		ready = false
-		msg = fmt.Sprintf("datastore not ready: %s", target.GetCondition(ConditionTypeDatastoreReady).Message)
+		msg = fmt.Sprintf("datastore not ready") // target.GetCondition(ConditionTypeDatastoreReady).Message)
 	}
 	if ready && !target.GetCondition(ConditionTypeConfigReady).IsTrue() {
 		ready = false
-		msg = fmt.Sprintf("config not ready: %s", target.GetCondition(ConditionTypeConfigReady).Message)
+		msg = fmt.Sprintf("config not ready")//, target.GetCondition(ConditionTypeConfigReady).Message)
 	}
 	if ready && !target.GetCondition(ConditionTypeTargetConnectionReady).IsTrue() {
 		ready = false
-		msg =fmt.Sprintf("datastore connection not ready: %s", target.GetCondition(ConditionTypeTargetConnectionReady).Message)
+		msg =fmt.Sprintf("datastore connection not ready")// target.GetCondition(ConditionTypeTargetConnectionReady).Message)
 	}
 	if ready {
 		r.Status.SetConditions(condv1alpha1.Ready())

--- a/apis/inv/v1alpha1/target_helpers.go
+++ b/apis/inv/v1alpha1/target_helpers.go
@@ -42,24 +42,24 @@ func (r *Target) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
 }
 
-func (r *Target) SetOverallStatus() {
+func (r *Target) SetOverallStatus(target *Target) {
 	ready := true
 	msg := "target ready"
-	if ready && !r.GetCondition(ConditionTypeDiscoveryReady).IsTrue() {
+	if ready && !target.GetCondition(ConditionTypeDiscoveryReady).IsTrue() {
 		ready = false
-		msg = "discovery not ready"
+		msg = fmt.Sprintf("discovery not ready: %s", target.GetCondition(ConditionTypeDiscoveryReady).Message)
 	}
-	if ready && !r.GetCondition(ConditionTypeDatastoreReady).IsTrue() {
+	if ready && !target.GetCondition(ConditionTypeDatastoreReady).IsTrue() {
 		ready = false
-		msg = "datastore not ready"
+		msg = fmt.Sprintf("datastore not ready: %s", target.GetCondition(ConditionTypeDatastoreReady).Message)
 	}
-	if ready && !r.GetCondition(ConditionTypeConfigReady).IsTrue() {
+	if ready && !target.GetCondition(ConditionTypeConfigReady).IsTrue() {
 		ready = false
-		msg = "config not ready"
+		msg = fmt.Sprintf("config not ready: %s", target.GetCondition(ConditionTypeConfigReady).Message)
 	}
-	if ready && !r.GetCondition(ConditionTypeTargetConnectionReady).IsTrue() {
+	if ready && !target.GetCondition(ConditionTypeTargetConnectionReady).IsTrue() {
 		ready = false
-		msg = "target connection not ready"
+		msg =fmt.Sprintf("datastore connection not ready: %s", target.GetCondition(ConditionTypeTargetConnectionReady).Message)
 	}
 	if ready {
 		r.Status.SetConditions(condv1alpha1.Ready())

--- a/apis/inv/v1alpha1/target_types.go
+++ b/apis/inv/v1alpha1/target_types.go
@@ -27,21 +27,25 @@ import (
 // TargetSpec defines the desired state of Target
 type TargetSpec struct {
 	// Provider specifies the provider using this target.
-	Provider string `json:"provider" yaml:"provider" protobuf:"bytes,1,opt,name=provider"`
+	Provider string `json:"provider" protobuf:"bytes,1,opt,name=provider"`
 	// Address defines the address to connect to the target
-	Address string `json:"address" yaml:"address" protobuf:"bytes,2,opt,name=address"`
+	Address string `json:"address" protobuf:"bytes,2,opt,name=address"`
 	// TargetProfile defines the Credentials/TLSSecret and sync/connectivity profile to connect to the target
-	TargetProfile `json:",inline" yaml:",inline" protobuf:"bytes,3,opt,name=targetProfile"`
+	TargetProfile `json:",inline" protobuf:"bytes,3,opt,name=targetProfile"`
 }
 
 // TargetStatus defines the observed state of Target
 type TargetStatus struct {
 	// ConditionedStatus provides the status of the Target using conditions
-	condv1alpha1.ConditionedStatus `json:",inline" yaml:",inline" protobuf:"bytes,1,opt,name=conditionedStatus"`
+	condv1alpha1.ConditionedStatus `json:",inline" protobuf:"bytes,1,opt,name=conditionedStatus"`
 	// Discovery info defines the information retrieved during discovery
-	DiscoveryInfo *DiscoveryInfo `json:"discoveryInfo,omitempty" yaml:"discoveryInfo,omitempty" protobuf:"bytes,2,opt,name=discoveryInfo"`
+	DiscoveryInfo *DiscoveryInfo `json:"discoveryInfo,omitempty" protobuf:"bytes,2,opt,name=discoveryInfo"`
 	// UsedReferences track the resource used to reconcile the cr
-	UsedReferences *TargetStatusUsedReferences `json:"usedReferences,omitempty" yaml:"usedReferences,omitempty" protobuf:"bytes,3,opt,name=usedReferences"`
+	UsedReferences *TargetStatusUsedReferences `json:"usedReferences,omitempty" protobuf:"bytes,3,opt,name=usedReferences"`
+	// ResourceVersion used by recovery
+	ResourceVersion *string `json:"resourceVersion" protobuf:"bytes,4,opt,name=resourceVersion"`
+	// Generation used by recovery
+	Generation *int64 `json:"generation" protobuf:"bytes,5,opt,name=generation"`
 }
 
 type DiscoveryInfo struct {

--- a/apis/inv/v1alpha1/target_types.go
+++ b/apis/inv/v1alpha1/target_types.go
@@ -43,9 +43,9 @@ type TargetStatus struct {
 	// UsedReferences track the resource used to reconcile the cr
 	UsedReferences *TargetStatusUsedReferences `json:"usedReferences,omitempty" protobuf:"bytes,3,opt,name=usedReferences"`
 	// ResourceVersion used by recovery
-	ResourceVersion *string `json:"resourceVersion" protobuf:"bytes,4,opt,name=resourceVersion"`
+	ResourceVersion *string `json:"resourceVersion,omitempty" protobuf:"bytes,4,opt,name=resourceVersion"`
 	// Generation used by recovery
-	Generation *int64 `json:"generation" protobuf:"bytes,5,opt,name=generation"`
+	Generation *int64 `json:"generation,omitempty" protobuf:"bytes,5,opt,name=generation"`
 }
 
 type DiscoveryInfo struct {

--- a/artifacts/in/configmap-input-vars.yaml
+++ b/artifacts/in/configmap-input-vars.yaml
@@ -6,4 +6,5 @@ data:
   #configServerImage: europe-docker.pkg.dev/srlinux/eu.gcr.io/config-server:latest
   #dataServerImage: ghcr.io/sdcio/data-server:v0.0.53
   configServerImage: europe-docker.pkg.dev/srlinux/eu.gcr.io/config-server:latest
-  dataServerImage: ghcr.io/steiler/data-server:v0.0.0-bbd639d
+  dataServerImage: ghcr.io/sdcio/data-server:v0.0.54
+  #dataServerImage: ghcr.io/steiler/data-server:v0.0.0-bbd639d

--- a/artifacts/inv.sdcio.dev_targets.yaml
+++ b/artifacts/inv.sdcio.dev_targets.yaml
@@ -210,9 +210,6 @@ spec:
                 - connectionProfileResourceVersion
                 - syncProfileResourceVersion
                 type: object
-            required:
-            - generation
-            - resourceVersion
             type: object
         type: object
     served: true

--- a/artifacts/inv.sdcio.dev_targets.yaml
+++ b/artifacts/inv.sdcio.dev_targets.yaml
@@ -187,6 +187,13 @@ spec:
                     description: Version associated with the target
                     type: string
                 type: object
+              generation:
+                description: Generation used by recovery
+                format: int64
+                type: integer
+              resourceVersion:
+                description: ResourceVersion used by recovery
+                type: string
               usedReferences:
                 description: UsedReferences track the resource used to reconcile the
                   cr
@@ -203,6 +210,9 @@ spec:
                 - connectionProfileResourceVersion
                 - syncProfileResourceVersion
                 type: object
+            required:
+            - generation
+            - resourceVersion
             type: object
         type: object
     served: true

--- a/crds/inv.sdcio.dev_targets.yaml
+++ b/crds/inv.sdcio.dev_targets.yaml
@@ -210,9 +210,6 @@ spec:
                 - connectionProfileResourceVersion
                 - syncProfileResourceVersion
                 type: object
-            required:
-            - generation
-            - resourceVersion
             type: object
         type: object
     served: true

--- a/crds/inv.sdcio.dev_targets.yaml
+++ b/crds/inv.sdcio.dev_targets.yaml
@@ -187,6 +187,13 @@ spec:
                     description: Version associated with the target
                     type: string
                 type: object
+              generation:
+                description: Generation used by recovery
+                format: int64
+                type: integer
+              resourceVersion:
+                description: ResourceVersion used by recovery
+                type: string
               usedReferences:
                 description: UsedReferences track the resource used to reconcile the
                   cr
@@ -203,6 +210,9 @@ spec:
                 - connectionProfileResourceVersion
                 - syncProfileResourceVersion
                 type: object
+            required:
+            - generation
+            - resourceVersion
             type: object
         type: object
     served: true

--- a/pkg/discovery/discoveryrule/target.go
+++ b/pkg/discovery/discoveryrule/target.go
@@ -152,7 +152,7 @@ func (r *dr) applyTarget(ctx context.Context, targetNew *invv1alpha1.Target) err
 	)
 
 	// Apply the patch
-	err := r.client.Status().Patch(ctx, targetPatch, client.MergeFrom(targetCurrent), &client.SubResourcePatchOptions{
+	err := r.client.Status().Patch(ctx, targetPatch, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/discovery/discoveryrule/target.go
+++ b/pkg/discovery/discoveryrule/target.go
@@ -144,8 +144,8 @@ func (r *dr) applyTarget(ctx context.Context, targetNew *invv1alpha1.Target) err
 			Namespace: targetNew.Namespace,
 			Name:      targetNew.Name,
 		},
-		targetNew.Spec,
-		targetNew.Status,
+		targetCurrent.Spec,
+		targetCurrent.Status,
 	)
 	target.Status.SetConditions(invv1alpha1.DiscoveryReady())
 	err := r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{

--- a/pkg/discovery/discoveryrule/target.go
+++ b/pkg/discovery/discoveryrule/target.go
@@ -151,7 +151,7 @@ func (r *dr) applyTarget(ctx context.Context, targetNew *invv1alpha1.Target) err
 	newTarget.SetConditions(target.GetCondition(invv1alpha1.ConditionTypeDiscoveryReady))
 	// set new conditions
 	newTarget.Status.SetConditions(invv1alpha1.DiscoveryReady())
-	err := r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
+	err := r.client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/discovery/discoveryrule/target.go
+++ b/pkg/discovery/discoveryrule/target.go
@@ -145,7 +145,7 @@ func (r *dr) applyTarget(ctx context.Context, targetNew *invv1alpha1.Target) err
 			Name:      targetNew.Name,
 		},
 		targetCurrent.Spec,
-		targetCurrent.Status,
+		targetNew.Status,
 	)
 	target.Status.SetConditions(invv1alpha1.DiscoveryReady())
 	err := r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -190,7 +190,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, cfg *configv1alpha1.Conf
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", cfg.GetNamespacedName(), "status old", cfg.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(cfg.DeepCopy())
+	//patch := client.MergeFrom(cfg.DeepCopy())
 	// update status
 	cfg.SetConditions(condv1alpha1.ReadyWithMsg(msg))
 	cfg.Status.LastKnownGoodSchema = schema
@@ -200,7 +200,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, cfg *configv1alpha1.Conf
 
 	log.Debug("handleSuccess", "key", cfg.GetNamespacedName(), "status new", cfg.Status)
 
-	return r.Client.Status().Patch(ctx, cfg, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, cfg, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -210,7 +210,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, cfg *configv1alpha1.Conf
 func (r *reconciler) handleError(ctx context.Context, cfg *configv1alpha1.Config, msg string, err error, recoverable bool) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(cfg.DeepCopy())
+	//patch := client.MergeFrom(cfg.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -236,7 +236,7 @@ func (r *reconciler) handleError(ctx context.Context, cfg *configv1alpha1.Config
 	log.Error(msg)
 	r.recorder.Eventf(cfg, corev1.EventTypeWarning, configv1alpha1.ConfigKind, msg)
 
-	return r.Client.Status().Patch(ctx, cfg, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, cfg, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -145,10 +145,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if _, _, err := r.targetHandler.GetTargetContext(ctx, targetKey); err != nil {
-		cfg.Status.LastKnownGoodSchema = nil
-		cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
-		cfg.Status.AppliedConfig = &cfg.Spec
-		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, cfgOrig, "target error", err, true), errUpdateStatus)
+		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, cfgOrig, "target not ready", err, true), errUpdateStatus)
 	}
 
 	// check if we have to reapply the config
@@ -218,6 +215,10 @@ func (r *reconciler) handleError(ctx context.Context, cfg *configv1alpha1.Config
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
+
+	cfg.Status.LastKnownGoodSchema = nil
+	cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
+	cfg.Status.AppliedConfig = &cfg.Spec
 
 	if recoverable {
 		cfg.SetConditions(condv1alpha1.Failed(msg))

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -192,6 +192,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, cfg *configv1alpha1.Conf
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(cfg.DeepCopy())
 	// update status
+	cfg.ObjectMeta.ManagedFields = nil
 	cfg.SetConditions(condv1alpha1.ReadyWithMsg(msg))
 	cfg.Status.LastKnownGoodSchema = schema
 	cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
@@ -219,7 +220,7 @@ func (r *reconciler) handleError(ctx context.Context, cfg *configv1alpha1.Config
 	//cfg.Status.LastKnownGoodSchema = nil
 	//cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
 	//cfg.Status.AppliedConfig = &cfg.Spec
-
+	cfg.ObjectMeta.ManagedFields = nil
 	if recoverable {
 		cfg.SetConditions(condv1alpha1.Failed(msg))
 	} else {

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -174,7 +174,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		var txErr *target.TransactionError
 		if errors.As(err, &txErr) && txErr.Recoverable {
 			// Retry logic for recoverable errors
-
 			return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second},
 				errors.Wrap(r.handleError(ctx, cfgOrig, processMessageWithWarning("set intent failed (recoverable)", warnings), err, true), errUpdateStatus)
 		}

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -111,7 +111,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if !cfg.GetDeletionTimestamp().IsZero() {
 		if _, err := r.targetHandler.DeleteIntent(ctx, targetKey, internalcfg, false); err != nil {
-			if errors.Is(err, target.ErrLookup) {
+			if errors.Is(err, target.TargetLookupErr) {
+				log.Warn("deleted config, target unavailable", "config", req, "err", err)
 				// Since the target is not available we delete the resource
 				// The target config might not be deleted
 				if err := r.finalizer.RemoveFinalizer(ctx, cfg); err != nil {

--- a/pkg/reconcilers/config/reconciler.go
+++ b/pkg/reconcilers/config/reconciler.go
@@ -216,9 +216,9 @@ func (r *reconciler) handleError(ctx context.Context, cfg *configv1alpha1.Config
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
 
-	cfg.Status.LastKnownGoodSchema = nil
-	cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
-	cfg.Status.AppliedConfig = &cfg.Spec
+	//cfg.Status.LastKnownGoodSchema = nil
+	//cfg.Status.Deviations = []configv1alpha1.Deviation{} // reset deviations
+	//cfg.Status.AppliedConfig = &cfg.Spec
 
 	if recoverable {
 		cfg.SetConditions(condv1alpha1.Failed(msg))

--- a/pkg/reconcilers/configset/reconciler.go
+++ b/pkg/reconcilers/configset/reconciler.go
@@ -328,14 +328,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, configSet *configv1alpha
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", configSet.GetNamespacedName(), "status old", configSet.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(configSet.DeepCopy())
+	//patch := client.MergeFrom(configSet.DeepCopy())
 	// update status
 	configSet.SetConditions(condv1alpha1.Ready())
 	r.recorder.Eventf(configSet, corev1.EventTypeNormal, configv1alpha1.ConfigSetKind, "ready")
 
 	log.Debug("handleSuccess", "key", configSet.GetNamespacedName(), "status new", configSet.Status)
 
-	return r.Client.Status().Patch(ctx, configSet, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, configSet, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -345,7 +345,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, configSet *configv1alpha
 func (r *reconciler) handleError(ctx context.Context, configSet *configv1alpha1.ConfigSet, msg string, err error) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(configSet.DeepCopy())
+	//patch := client.MergeFrom(configSet.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -354,7 +354,7 @@ func (r *reconciler) handleError(ctx context.Context, configSet *configv1alpha1.
 	log.Error(msg)
 	r.recorder.Eventf(configSet, corev1.EventTypeWarning, configv1alpha1.ConfigSetKind, msg)
 
-	return r.Client.Status().Patch(ctx, configSet, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, configSet, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/configset/reconciler.go
+++ b/pkg/reconcilers/configset/reconciler.go
@@ -330,6 +330,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, configSet *configv1alpha
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(configSet.DeepCopy())
 	// update status
+	configSet.ObjectMeta.ManagedFields = nil
 	configSet.SetConditions(condv1alpha1.Ready())
 	r.recorder.Eventf(configSet, corev1.EventTypeNormal, configv1alpha1.ConfigSetKind, "ready")
 
@@ -350,6 +351,7 @@ func (r *reconciler) handleError(ctx context.Context, configSet *configv1alpha1.
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
+	configSet.ObjectMeta.ManagedFields = nil
 	configSet.SetConditions(condv1alpha1.Failed(msg))
 	log.Error(msg)
 	r.recorder.Eventf(configSet, corev1.EventTypeWarning, configv1alpha1.ConfigSetKind, msg)

--- a/pkg/reconcilers/discoveryrule/reconciler.go
+++ b/pkg/reconcilers/discoveryrule/reconciler.go
@@ -259,6 +259,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, discoveryRule *invv1alph
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(discoveryRule.DeepCopy())
 	// update status
+	discoveryRule.ObjectMeta.ManagedFields = nil
 	discoveryRule.SetConditions(condv1alpha1.Ready())
 	if changed {
 		discoveryRule.Status.StartTime = metav1.Now()
@@ -282,6 +283,7 @@ func (r *reconciler) handleError(ctx context.Context, discoveryRule *invv1alpha1
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
+	discoveryRule.ObjectMeta.ManagedFields = nil
 	discoveryRule.Status.StartTime = metav1.Time{}
 	discoveryRule.SetConditions(condv1alpha1.Failed(msg))
 	log.Error(msg)

--- a/pkg/reconcilers/discoveryrule/reconciler.go
+++ b/pkg/reconcilers/discoveryrule/reconciler.go
@@ -257,7 +257,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, discoveryRule *invv1alph
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", discoveryRule.GetNamespacedName(), "status old", discoveryRule.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(discoveryRule.DeepCopy())
+	//patch := client.MergeFrom(discoveryRule.DeepCopy())
 	// update status
 	discoveryRule.SetConditions(condv1alpha1.Ready())
 	if changed {
@@ -267,7 +267,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, discoveryRule *invv1alph
 
 	log.Debug("handleSuccess", "key", discoveryRule.GetNamespacedName(), "status new", discoveryRule.Status)
 
-	return r.Client.Status().Patch(ctx, discoveryRule, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, discoveryRule, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -277,7 +277,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, discoveryRule *invv1alph
 func (r *reconciler) handleError(ctx context.Context, discoveryRule *invv1alpha1.DiscoveryRule, msg string, err error) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(discoveryRule.DeepCopy())
+	//patch := client.MergeFrom(discoveryRule.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -287,7 +287,7 @@ func (r *reconciler) handleError(ctx context.Context, discoveryRule *invv1alpha1
 	log.Error(msg)
 	r.recorder.Eventf(discoveryRule, corev1.EventTypeWarning, invv1alpha1.DiscoveryRuleKind, msg)
 
-	return r.Client.Status().Patch(ctx, discoveryRule, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, discoveryRule, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/rollout/reconciler.go
+++ b/pkg/reconcilers/rollout/reconciler.go
@@ -321,6 +321,7 @@ func (r *reconciler) handleStatus(
 	if err != nil {
 		condition.Message = fmt.Sprintf("%s err %s", condition.Message, err.Error())
 	}
+	rollout.ManagedFields = nil
 	rollout.SetConditions(condition)
 	rollout.Status.Targets = getTargetStatus(ctx, targetStatus)
 

--- a/pkg/reconcilers/rollout/reconciler.go
+++ b/pkg/reconcilers/rollout/reconciler.go
@@ -317,7 +317,7 @@ func (r *reconciler) handleStatus(
 	err error,
 ) (ctrl.Result, error) {
 	log := log.FromContext(ctx).With("ref", rollout.Spec.Ref)
-	patch := client.MergeFrom(rollout.DeepCopy())
+	//patch := client.MergeFrom(rollout.DeepCopy())
 	if err != nil {
 		condition.Message = fmt.Sprintf("%s err %s", condition.Message, err.Error())
 	}
@@ -331,7 +331,7 @@ func (r *reconciler) handleStatus(
 		r.recorder.Eventf(rollout, corev1.EventTypeWarning, crName, condition.Message)
 	}
 	result := ctrl.Result{Requeue: requeue}
-	return result, pkgerrors.Wrap(r.Client.Status().Patch(ctx, rollout, patch, &client.SubResourcePatchOptions{
+	return result, pkgerrors.Wrap(r.Client.Status().Patch(ctx, rollout, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/schema/reconciler.go
+++ b/pkg/reconcilers/schema/reconciler.go
@@ -230,6 +230,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, schema *invv1alpha1.Sche
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(schema.DeepCopy())
 	// update status
+	schema.ObjectMeta.ManagedFields = nil
 	schema.SetConditions(condv1alpha1.Ready())
 	r.recorder.Eventf(schema, corev1.EventTypeNormal, invv1alpha1.SchemaKind, "ready")
 
@@ -251,7 +252,7 @@ func (r *reconciler) handleError(ctx context.Context, schema *invv1alpha1.Schema
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
-
+	schema.ManagedFields = nil
 	schema.SetConditions(condv1alpha1.Failed(msg))
 	log.Error(msg)
 	r.recorder.Eventf(schema, corev1.EventTypeWarning, crName, msg)

--- a/pkg/reconcilers/schema/reconciler.go
+++ b/pkg/reconcilers/schema/reconciler.go
@@ -228,14 +228,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, schema *invv1alpha1.Sche
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", schema.GetNamespacedName(), "status old", schema.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(schema.DeepCopy())
+	//patch := client.MergeFrom(schema.DeepCopy())
 	// update status
 	schema.SetConditions(condv1alpha1.Ready())
 	r.recorder.Eventf(schema, corev1.EventTypeNormal, invv1alpha1.SchemaKind, "ready")
 
 	log.Debug("handleSuccess", "key", schema.GetNamespacedName(), "status new", schema.Status)
 
-	return ctrl.Result{}, pkgerrors.Wrap(r.Client.Status().Patch(ctx, schema, patch, &client.SubResourcePatchOptions{
+	return ctrl.Result{}, pkgerrors.Wrap(r.Client.Status().Patch(ctx, schema, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/subscription/reconciler.go
+++ b/pkg/reconcilers/subscription/reconciler.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sdcio/config-server/pkg/reconcilers/ctrlconfig"
 	"github.com/sdcio/config-server/pkg/reconcilers/eventhandler"
 	"github.com/sdcio/config-server/pkg/reconcilers/resource"
-	sdcctx "github.com/sdcio/config-server/pkg/sdc/ctx"
 	sdctarget "github.com/sdcio/config-server/pkg/target"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +80,7 @@ type reconciler struct {
 	client.Client
 	finalizer       *resource.APIFinalizer
 	targetStore     storebackend.Storer[*sdctarget.Context]
-	dataServerStore storebackend.Storer[sdcctx.DSContext]
+	//dataServerStore storebackend.Storer[sdcctx.DSContext]
 	recorder        record.EventRecorder
 }
 
@@ -184,7 +183,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, state *invv1alpha1.Subsc
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", state.GetNamespacedName(), "status old", state.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(state.DeepCopy())
+	//patch := client.MergeFrom(state.DeepCopy())
 	// update status
 	state.SetConditions(condv1alpha1.Ready())
 	state.SetTargets(targets)
@@ -192,7 +191,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, state *invv1alpha1.Subsc
 
 	log.Debug("handleSuccess", "key", state.GetNamespacedName(), "status new", state.Status)
 
-	return ctrl.Result{}, pkgerrors.Wrap(r.Client.Status().Patch(ctx, state, patch, &client.SubResourcePatchOptions{
+	return ctrl.Result{}, pkgerrors.Wrap(r.Client.Status().Patch(ctx, state, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/subscription/reconciler.go
+++ b/pkg/reconcilers/subscription/reconciler.go
@@ -207,7 +207,7 @@ func (r *reconciler) handleError(ctx context.Context, state *invv1alpha1.Subscri
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
-
+	state.ObjectMeta.ManagedFields = nil
 	state.SetConditions(condv1alpha1.Failed(msg))
 	log.Error(msg)
 	r.recorder.Eventf(state, corev1.EventTypeWarning, crName, msg)

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -204,7 +204,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 		invv1alpha1.TargetSpec{},
 		invv1alpha1.TargetStatus{},
 	)
-	target.Status.SetConditions(invv1alpha1.DiscoveryReady())
+	//target.Status.SetConditions(invv1alpha1.DiscoveryReady())
 	target.SetConditions(invv1alpha1.TargetConnectionFailed(msg))
 	target.SetOverallStatus()
 	log.Error(msg, "error", err)

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/sdcio/config-server/pkg/reconcilers"
 	"github.com/sdcio/config-server/pkg/reconcilers/ctrlconfig"
 	"github.com/sdcio/config-server/pkg/reconcilers/resource"
-	sdcctx "github.com/sdcio/config-server/pkg/sdc/ctx"
 	sdctarget "github.com/sdcio/config-server/pkg/target"
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +77,6 @@ type reconciler struct {
 	client.Client
 	finalizer       *resource.APIFinalizer
 	targetStore     storebackend.Storer[*sdctarget.Context]
-	dataServerStore storebackend.Storer[sdcctx.DSContext]
 	recorder        record.EventRecorder
 }
 
@@ -178,7 +176,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 		target.SetStatusGeneration()
 		target.SetStatusResourceVersion()
 	}
-	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
+	//r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
 

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -170,13 +170,12 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 
 	}
 	target.SetOverallStatus()
-	target.SetStatusResourceVersion()
 	// if ready update the resourceversion in the status -> goal is to use this to prevent recovering again
 	if target.IsReady() {
 		target.SetStatusGeneration()
 		target.SetStatusResourceVersion()
 	}
-	//r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
+	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
 

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -181,16 +181,22 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// set new conditions
 	newTarget.SetConditions(invv1alpha1.TargetConnectionReady())
 	newTarget.SetOverallStatus(target)
-	
-	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
-
-	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)
 
 
 	result := ctrl.Result{RequeueAfter: 5 * time.Minute}
 	if !target.IsReady() {
 		result= ctrl.Result{Requeue: true}
 	}	
+
+	// we don't update the resource if no condition changed
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)) &&
+		newTarget.GetCondition(condv1alpha1.ConditionTypeReady).Equal(target.GetCondition(condv1alpha1.ConditionTypeReady)) {
+			return result, nil
+	}
+	
+	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
+
+	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)
 
 	return result, r.Client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -163,7 +163,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.TargetConnectionReady())
 	target.SetOverallStatus()
@@ -172,7 +172,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
 
-	return r.Client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -182,7 +182,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target, msg string, err error) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -192,7 +192,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	log.Error(msg, "error", err)
 	r.recorder.Eventf(target, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 
-	return r.Client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -147,7 +147,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if errs := r.targetStore.UpdateWithKeyFn(ctx, targetKey, func(ctx context.Context, tctx *sdctarget.Context) *sdctarget.Context {
 		if tctx != nil {
-			tctx.SetReady(ctx)
+			tctx.SetResourceVersionAndGeneration(ctx, target.GetResourceVersion(), target.GetGeneration())
 		}
 		return tctx
 	}); errs != nil {
@@ -166,15 +166,8 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.TargetConnectionReady())
-	if target.IsReady() {
-
-	}
 	target.SetOverallStatus()
-	// if ready update the resourceversion in the status -> goal is to use this to prevent recovering again
-	if target.IsReady() {
-		target.SetStatusGeneration()
-		target.SetStatusResourceVersion()
-	}
+	
 	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -148,7 +148,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if errs := r.targetStore.UpdateWithKeyFn(ctx, targetKey, func(ctx context.Context, tctx *sdctarget.Context) *sdctarget.Context {
 		if tctx != nil {
-			tctx.SetResourceVersionAndGeneration(ctx, target.GetResourceVersion(), target.GetGeneration())
+			tctx.SetReady(ctx)
 		}
 		return tctx
 	}); errs != nil {

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -196,7 +196,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
 
-	target = invv1alpha1.BuildTarget(
+	newTarget := invv1alpha1.BuildTarget(
 		metav1.ObjectMeta{
 			Namespace: target.Namespace,
 			Name:      target.Name,
@@ -205,12 +205,12 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 		invv1alpha1.TargetStatus{},
 	)
 	//target.Status.SetConditions(invv1alpha1.DiscoveryReady())
-	target.SetConditions(invv1alpha1.TargetConnectionFailed(msg))
-	target.SetOverallStatus()
+	newTarget.SetConditions(invv1alpha1.TargetConnectionFailed(msg))
+	newTarget.SetOverallStatus()
 	log.Error(msg, "error", err)
-	r.recorder.Eventf(target, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
+	r.recorder.Eventf(newTarget, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 
-	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -188,7 +188,6 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 		result= ctrl.Result{Requeue: true}
 	}
 	
-
 	// we don't update the resource if no condition changed
 	if newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)) &&
 		newTarget.GetCondition(condv1alpha1.ConditionTypeReady).Equal(target.GetCondition(condv1alpha1.ConditionTypeReady)) {

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -168,7 +168,16 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.TargetConnectionReady())
+	if target.IsReady() {
+
+	}
 	target.SetOverallStatus()
+	target.SetStatusResourceVersion()
+	// if ready update the resourceversion in the status -> goal is to use this to prevent recovering again
+	if target.IsReady() {
+		target.SetStatusGeneration()
+		target.SetStatusResourceVersion()
+	}
 	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -165,6 +165,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
+	target = invv1alpha1.BuildTarget(
+		metav1.ObjectMeta{
+			Namespace: target.Namespace,
+			Name:      target.Name,
+		},
+		invv1alpha1.TargetSpec{},
+		invv1alpha1.TargetStatus{},
+	)
 	target.SetConditions(invv1alpha1.TargetConnectionReady())
 	target.SetOverallStatus()
 	
@@ -187,6 +195,16 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
+
+	target = invv1alpha1.BuildTarget(
+		metav1.ObjectMeta{
+			Namespace: target.Namespace,
+			Name:      target.Name,
+		},
+		invv1alpha1.TargetSpec{},
+		invv1alpha1.TargetStatus{},
+	)
+	target.Status.SetConditions(invv1alpha1.DiscoveryReady())
 	target.SetConditions(invv1alpha1.TargetConnectionFailed(msg))
 	target.SetOverallStatus()
 	log.Error(msg, "error", err)

--- a/pkg/reconcilers/target/reconciler.go
+++ b/pkg/reconcilers/target/reconciler.go
@@ -186,14 +186,20 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	result := ctrl.Result{RequeueAfter: 5 * time.Minute}
 	if !target.IsReady() {
 		result= ctrl.Result{Requeue: true}
-	}	
+	}
+	
 
 	// we don't update the resource if no condition changed
 	if newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)) &&
 		newTarget.GetCondition(condv1alpha1.ConditionTypeReady).Equal(target.GetCondition(condv1alpha1.ConditionTypeReady)) {
+			log.Info("handleSuccess -> no change")
 			return result, nil
 	}
-	
+	log.Info("handleSuccess -> change", 
+			"connReady condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)),
+			"Ready condition change", newTarget.GetCondition(condv1alpha1.ConditionTypeReady).Equal(target.GetCondition(condv1alpha1.ConditionTypeReady)),
+	)
+
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "ready")
 
 	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -125,8 +125,10 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// if the config is recovered we can stop the reconcile loop
 	if tctx.IsConfigRecovered(ctx) {
+		log.Info("config recovered, no action required")
 		return ctrl.Result{}, nil
 	}
+	log.Info("recovering config ....")
 
 	// we split the config in config that were successfully applied and config that was not yet
 	recoveryConfigs, err := r.getRecoveryConfigs(ctx, target)

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -183,7 +183,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
-	target = invv1alpha1.BuildTarget(
+	newTarget := invv1alpha1.BuildTarget(
 		metav1.ObjectMeta{
 			Namespace: target.Namespace,
 			Name:      target.Name,
@@ -191,12 +191,13 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 		invv1alpha1.TargetSpec{},
 		invv1alpha1.TargetStatus{},
 	)
-	target.SetConditions(invv1alpha1.ConfigFailed(msg))
+	newTarget.ManagedFields = nil
+	newTarget.SetConditions(invv1alpha1.ConfigFailed(msg))
 	//target.SetOverallStatus()
 	log.Error(msg, "error", err)
-	r.recorder.Eventf(target, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
+	r.recorder.Eventf(newTarget, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 
-	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -127,8 +127,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, string(configv1alpha1.ConditionReasonTargetNotReady), nil), errUpdateStatus)
 	}
 
-	// if the resource version and generation did not change we dont have to recover again
-	if !target.HasResourceversionAndGenerationChanged() {
+	// validates if the resource version and target changed since the last ready state.
+	if !tctx.HasResourceVersionAndGenerationChanged(ctx, target.GetResourceVersion(), target.GetGeneration()) {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -127,6 +127,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, string(configv1alpha1.ConditionReasonTargetNotReady), nil), errUpdateStatus)
 	}
 
+	// if the resource version and generation did not change we dont have to recover again
+	if !target.HasResourceversionAndGenerationChanged() {
+		return ctrl.Result{}, nil
+	}
+
 	// we split the config in config that were successfully applied and config that was not yet
 	recoveryConfigs, err := r.getRecoveryConfigs(ctx, target)
 	if err != nil {

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -116,6 +116,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// to reapply existing configs we should check if the datastore is ready and if the target context is ready
+	// DataStore ready means: target is discovered, datastore is created and connection to the dataserver is up + target context is ready
 	ready, tctx := r.IsTargetDataStoreReady(ctx, targetKey, target)
 	if !ready {
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, string(configv1alpha1.ConditionReasonTargetNotReady), nil), errUpdateStatus)

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -143,7 +143,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Info("config recovery new ....")
 
 	// We need to restore the config on the target
-	//for _, config := range configsToReApply {
 	msg, err := tctx.RecoverIntents(ctx, targetKey, recoveryConfigs)
 	if err != nil {
 		// This is bad since this means we cannot recover the applied config
@@ -151,7 +150,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Most likely a human intervention is needed
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, "setIntent failed", err), errUpdateStatus)
 	}
-	//}
 	return ctrl.Result{}, errors.Wrap(r.handleSuccess(ctx, targetOrig, msg), errUpdateStatus)
 }
 

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -177,9 +177,13 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)
 
 	// we don't update the resource if no condition changed
-	if newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)) {
-		 return nil
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeConfigReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeConfigReady)) {
+		// we don't update the resource if no condition changed
+		log.Info("handleSuccess -> no change")
+		return nil
 	}
+	log.Info("handleSuccess -> change", 
+			"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeConfigReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeConfigReady)))
 
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "config ready")
 
@@ -213,6 +217,14 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	//target.SetOverallStatus()
 	log.Error(msg, "error", err)
 	r.recorder.Eventf(newTarget, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
+
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeConfigReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeConfigReady)) {
+		// we don't update the resource if no condition changed
+		log.Info("handleError -> no change")
+		return nil
+	}
+	log.Info("handleError -> change", 
+			"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeConfigReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeConfigReady)))
 
 	return r.Client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -167,9 +167,15 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	newTarget.SetConditions(target.GetCondition(invv1alpha1.ConditionTypeConfigReady))
 	// set new conditions
 	newTarget.SetConditions(invv1alpha1.ConfigReady(msg))
-	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "config ready")
-
+	
 	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)
+
+	// we don't update the resource if no condition changed
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady)) {
+		 return nil
+	}
+
+	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "config ready")
 
 	return r.Client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -125,10 +125,10 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// if the config is recovered we can stop the reconcile loop
 	if tctx.IsConfigRecovered(ctx) {
-		log.Info("config recovered, no action required")
+		log.Info("config recovery done")
 		return ctrl.Result{}, nil
 	}
-	log.Info("recovering config ....")
+	log.Info("config recovery new ....")
 
 	// we split the config in config that were successfully applied and config that was not yet
 	recoveryConfigs, err := r.getRecoveryConfigs(ctx, target)

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -151,7 +151,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	log := log.FromContext(ctx)
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.ConfigReady(msg))
 	//target.SetOverallStatus()
@@ -159,7 +159,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
 
-	return r.Client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -169,7 +169,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target, msg string, err error) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -179,7 +179,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	log.Error(msg, "error", err)
 	r.recorder.Eventf(target, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 
-	return r.Client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.Client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -225,10 +225,6 @@ func (r *reconciler) listTargetConfigs(ctx context.Context, target *invv1alpha1.
 
 func (r *reconciler) IsTargetDataStoreReady(ctx context.Context, key storebackend.Key, target *invv1alpha1.Target) (bool, *target.Context) {
 	log := log.FromContext(ctx)
-	// datastore not ready so we can wait till the target goes to ready state
-	if target.IsDatastoreReady() {
-		return false, nil
-	}
 	// we do not find the target Context -> target is not ready
 	tctx, err := r.targetStore.Get(ctx, key)
 	if err != nil {

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -137,7 +137,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if len(recoveryConfigs) == 0 {
 		log.Info("config recovery done, no configs to recover")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, errors.Wrap(r.handleSuccess(ctx, targetOrig, ""), errUpdateStatus)
 	}
 
 	log.Info("config recovery new ....")

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -122,6 +122,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// validates if the resource version and target changed since the last ready state.
+	// if not no need to recover again -> we can assume the target did not transition state
 	if !tctx.HasResourceVersionAndGenerationChanged(ctx, target.GetResourceVersion(), target.GetGeneration()) {
 		return ctrl.Result{}, nil
 	}

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -163,7 +163,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 		invv1alpha1.TargetStatus{},
 	)
 	// set old condition to avoid updating the new status if not changed
-	newTarget.SetConditions(target.GetCondition(invv1alpha1.ConditionTypeTargetConnectionReady))
+	newTarget.SetConditions(target.GetCondition(invv1alpha1.ConditionTypeConfigReady))
 	// set new conditions
 	newTarget.SetConditions(invv1alpha1.ConfigReady(msg))
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "config ready")

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -128,13 +128,19 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		log.Info("config recovery done")
 		return ctrl.Result{}, nil
 	}
-	log.Info("config recovery new ....")
 
 	// we split the config in config that were successfully applied and config that was not yet
 	recoveryConfigs, err := r.getRecoveryConfigs(ctx, target)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, "reapply config failed", err), errUpdateStatus)
 	}
+
+	if len(recoveryConfigs) == 0 {
+		log.Info("config recovery done, no configs to recover")
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("config recovery new ....")
 
 	// We need to restore the config on the target
 	//for _, config := range configsToReApply {

--- a/pkg/reconcilers/targetconfigserver/reconciler.go
+++ b/pkg/reconcilers/targetconfigserver/reconciler.go
@@ -123,9 +123,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, err.Error(), nil), errUpdateStatus)
 	}
 
-	// validates if the resource version and target changed since the last ready state.
-	// if not no need to recover again -> we can assume the target did not transition state
-	if !tctx.HasResourceVersionAndGenerationChanged(ctx, target.GetResourceVersion(), target.GetGeneration()) {
+	// if the config is recovered we can stop the reconcile loop
+	if tctx.IsConfigRecovered(ctx) {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -321,6 +321,13 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	newTarget.SetConditions(invv1alpha1.DatastoreReady())
 	newTarget.Status.UsedReferences = usedRefs
 	//target.SetOverallStatus()
+
+	// we don't update the resource if no condition changed
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)) &&
+		newTarget.Status.UsedReferences == target.Status.UsedReferences{
+		return nil
+   }
+
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
 
 	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -303,7 +303,7 @@ func (r *reconciler) updateStatusReinitializing(ctx context.Context, target *inv
 
 func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Target, usedRefs *invv1alpha1.TargetStatusUsedReferences) error {
 	log := log.FromContext(ctx)
-	log.Info("handleSuccess", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
+	//log.Info("handleSuccess", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
@@ -325,8 +325,11 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// we don't update the resource if no condition changed
 	if newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)) &&
 		newTarget.Status.UsedReferences == target.Status.UsedReferences{
+			log.Info("handleSuccess -> no change")
 		return nil
-   }
+	}
+	log.Info("handleSuccess", 
+				"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)))
 
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
 

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -295,7 +295,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
-	target = invv1alpha1.BuildTarget(
+	newTarget := invv1alpha1.BuildTarget(
 		metav1.ObjectMeta{
 			Namespace: target.Namespace,
 			Name:      target.Name,
@@ -303,14 +303,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 		invv1alpha1.TargetSpec{},
 		invv1alpha1.TargetStatus{},
 	)
-	target.SetConditions(invv1alpha1.DatastoreReady())
-	target.Status.UsedReferences = usedRefs
+	newTarget.SetConditions(invv1alpha1.DatastoreReady())
+	newTarget.Status.UsedReferences = usedRefs
 	//target.SetOverallStatus()
-	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
+	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
 
-	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
+	log.Debug("handleSuccess", "key", newTarget.GetNamespacedName(), "status new", target.Status)
 
-	return r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
+	return r.client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -264,14 +264,23 @@ func (r *reconciler) updateStatusReinitializing(ctx context.Context, target *inv
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
-	target.SetConditions(invv1alpha1.DatastoreFailed("reinitializing"))
-	target.Status.UsedReferences = nil
+
+	newTarget := invv1alpha1.BuildTarget(
+		metav1.ObjectMeta{
+			Namespace: target.Namespace,
+			Name:      target.Name,
+		},
+		invv1alpha1.TargetSpec{},
+		invv1alpha1.TargetStatus{},
+	)
+	newTarget.SetConditions(invv1alpha1.DatastoreFailed("reinitializing"))
+	newTarget.Status.UsedReferences = nil
 	//target.SetOverallStatus()
-	r.recorder.Eventf(target, corev1.EventTypeNormal, invv1alpha1.TargetKind, "reinitializing")
+	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "reinitializing")
 
-	log.Debug("updateStatusReinitializing", "key", target.GetNamespacedName(), "status new", target.Status)
+	log.Debug("updateStatusReinitializing", "key", newTarget.GetNamespacedName(), "status new", target.Status)
 
-	if err := r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
+	if err := r.client.Status().Patch(ctx, newTarget, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -321,18 +321,17 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// set new conditions
 	newTarget.SetConditions(invv1alpha1.DatastoreReady())
 	newTarget.Status.UsedReferences = usedRefs
-	//target.SetOverallStatus()
 
 	// we don't update the resource if no condition changed
 	if newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)) &&
 		equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences){
 			log.Info("handleSuccess -> no change")
 		return nil
-   }
-   log.Info("handleSuccess", 
-				"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)),
-				"shared ref change", equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences),
-			)
+	}
+	log.Info("handleSuccess", 
+		"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)),
+		"shared ref change", equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences),
+	)
 
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
 
@@ -369,6 +368,18 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	if resetUsedRefs {
 		newTarget.Status.UsedReferences = nil
 	}
+
+	// we don't update the resource if no condition changed
+	if newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)) &&
+		equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences){
+			log.Info("handleError -> no change")
+		return nil
+	}
+	log.Info("handleError", 
+		"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)),
+		"shared ref change", equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences),
+	)
+
 	log.Error(msg, "error", err)
 	r.recorder.Eventf(newTarget, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -295,6 +295,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	// take a snapshot of the current object
 	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
+	target = invv1alpha1.BuildTarget(
+		metav1.ObjectMeta{
+			Namespace: target.Namespace,
+			Name:      target.Name,
+		},
+		invv1alpha1.TargetSpec{},
+		invv1alpha1.TargetStatus{},
+	)
 	target.SetConditions(invv1alpha1.DatastoreReady())
 	target.Status.UsedReferences = usedRefs
 	//target.SetOverallStatus()
@@ -317,6 +325,14 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
 	}
+	target = invv1alpha1.BuildTarget(
+		metav1.ObjectMeta{
+			Namespace: target.Namespace,
+			Name:      target.Name,
+		},
+		invv1alpha1.TargetSpec{},
+		invv1alpha1.TargetStatus{},
+	)
 	target.SetConditions(invv1alpha1.DatastoreFailed(msg))
 	//target.SetOverallStatus()
 	if resetUsedRefs {

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -44,6 +44,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func init() {
@@ -324,12 +325,14 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 
 	// we don't update the resource if no condition changed
 	if newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)) &&
-		newTarget.Status.UsedReferences == target.Status.UsedReferences{
+		equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences){
 			log.Info("handleSuccess -> no change")
 		return nil
-	}
-	log.Info("handleSuccess", 
-				"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)))
+   }
+   log.Info("handleSuccess", 
+				"condition change", newTarget.GetCondition(invv1alpha1.ConditionTypeDatastoreReady).Equal(target.GetCondition(invv1alpha1.ConditionTypeDatastoreReady)),
+				"shared ref change", equality.Semantic.DeepEqual(newTarget.Status.UsedReferences, target.Status.UsedReferences),
+			)
 
 	r.recorder.Eventf(newTarget, corev1.EventTypeNormal, invv1alpha1.TargetKind, "datastore ready")
 

--- a/pkg/reconcilers/targetdatastore/reconciler.go
+++ b/pkg/reconcilers/targetdatastore/reconciler.go
@@ -262,7 +262,7 @@ func (r *reconciler) updateStatusReinitializing(ctx context.Context, target *inv
 	log := log.FromContext(ctx)
 	log.Debug("updateStatusReinitializing", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.DatastoreFailed("reinitializing"))
 	target.Status.UsedReferences = nil
@@ -271,7 +271,7 @@ func (r *reconciler) updateStatusReinitializing(ctx context.Context, target *inv
 
 	log.Debug("updateStatusReinitializing", "key", target.GetNamespacedName(), "status new", target.Status)
 
-	if err := r.client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	if err := r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -293,7 +293,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 	log := log.FromContext(ctx)
 	log.Info("handleSuccess", "key", target.GetNamespacedName(), "status old", target.DeepCopy().Status)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 	// update status
 	target.SetConditions(invv1alpha1.DatastoreReady())
 	target.Status.UsedReferences = usedRefs
@@ -302,7 +302,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 
 	log.Debug("handleSuccess", "key", target.GetNamespacedName(), "status new", target.Status)
 
-	return r.client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},
@@ -312,7 +312,7 @@ func (r *reconciler) handleSuccess(ctx context.Context, target *invv1alpha1.Targ
 func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target, msg string, err error, resetUsedRefs bool) error {
 	log := log.FromContext(ctx)
 	// take a snapshot of the current object
-	patch := client.MergeFrom(target.DeepCopy())
+	//patch := client.MergeFrom(target.DeepCopy())
 
 	if err != nil {
 		msg = fmt.Sprintf("%s err %s", msg, err.Error())
@@ -325,7 +325,7 @@ func (r *reconciler) handleError(ctx context.Context, target *invv1alpha1.Target
 	log.Error(msg, "error", err)
 	r.recorder.Eventf(target, corev1.EventTypeWarning, invv1alpha1.TargetKind, msg)
 
-	return r.client.Status().Patch(ctx, target, patch, &client.SubResourcePatchOptions{
+	return r.client.Status().Patch(ctx, target, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/workspace/reconciler.go
+++ b/pkg/reconcilers/workspace/reconciler.go
@@ -177,7 +177,7 @@ func (r *reconciler) handleStatus(
 ) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
-	patch := client.MergeFrom(workspace.DeepCopy())
+	//patch := client.MergeFrom(workspace.DeepCopy())
 
 	if err != nil {
 		condition.Message = fmt.Sprintf("%s err %s", condition.Message, err.Error())
@@ -194,7 +194,7 @@ func (r *reconciler) handleStatus(
 	}
 
 	result := ctrl.Result{Requeue: requeue}
-	return result, errors.Wrap(r.Client.Status().Patch(ctx, workspace, patch, &client.SubResourcePatchOptions{
+	return result, errors.Wrap(r.Client.Status().Patch(ctx, workspace, client.Apply, &client.SubResourcePatchOptions{
 		PatchOptions: client.PatchOptions{
 			FieldManager: reconcilerName,
 		},

--- a/pkg/reconcilers/workspace/reconciler.go
+++ b/pkg/reconcilers/workspace/reconciler.go
@@ -183,6 +183,7 @@ func (r *reconciler) handleStatus(
 		condition.Message = fmt.Sprintf("%s err %s", condition.Message, err.Error())
 	}
 
+	workspace.ManagedFields = nil
 	workspace.SetConditions(condition)
 
 	// Determine event type based on condition type

--- a/pkg/target/context.go
+++ b/pkg/target/context.go
@@ -178,6 +178,8 @@ func (r *Context) IsReady() bool {
 }
 
 func (r *Context) SetNotReady(ctx context.Context) {
+	log := log.FromContext(ctx)
+	log.Info("SetNotReady", "ready", r.getReady())
 	r.setReady(false)
 	if r.deviationWatcher != nil {
 		r.deviationWatcher.Stop(ctx)
@@ -189,6 +191,7 @@ func (r *Context) SetNotReady(ctx context.Context) {
 
 func (r *Context) SetReady(ctx context.Context) {
 	log := log.FromContext(ctx)
+	log.Info("SetReady", "ready", r.getReady())
 	// if we already are in ready state we can ignore
 	if r.getReady() {
 		return

--- a/pkg/target/context.go
+++ b/pkg/target/context.go
@@ -179,7 +179,7 @@ func (r *Context) IsReady() bool {
 
 func (r *Context) SetNotReady(ctx context.Context) {
 	log := log.FromContext(ctx)
-	log.Info("SetNotReady", "ready", r.getReady())
+	log.Info("SetNotReady", "ready", r.getReady(), "recoveredConfigs", r.getRecoveredConfigs())
 	r.setReady(false)
 	if r.deviationWatcher != nil {
 		r.deviationWatcher.Stop(ctx)
@@ -191,7 +191,7 @@ func (r *Context) SetNotReady(ctx context.Context) {
 
 func (r *Context) SetReady(ctx context.Context) {
 	log := log.FromContext(ctx)
-	log.Info("SetReady", "ready", r.getReady())
+	log.Info("SetReady", "ready", r.getReady(), "recoveredConfigs", r.getRecoveredConfigs())
 	// if we already are in ready state we can ignore
 	if r.getReady() {
 		return

--- a/pkg/target/deviation_watcher.go
+++ b/pkg/target/deviation_watcher.go
@@ -197,7 +197,7 @@ func (r *DeviationWatcher) processDeviations(ctx context.Context, deviations map
 
 func (r *DeviationWatcher) processConfigDeviations(ctx context.Context, nsn types.NamespacedName, cfg configv1alpha1.ConfigDeviations, devs []configv1alpha1.Deviation) {
 	log := log.FromContext(ctx)
-	if err := r.client.Get(ctx, r.targetKey.NamespacedName, cfg); err != nil {
+	if err := r.client.Get(ctx, nsn, cfg); err != nil {
 		log.Error("cannot get intent for recieved deviation", "config", nsn)
 		return 
 	}

--- a/pkg/target/error.go
+++ b/pkg/target/error.go
@@ -1,9 +1,14 @@
 package target
 
+import (
+	errors "errors"
+	"fmt"
+)
+
 // TransactionError represents an error with recoverability classification
 type TransactionError struct {
 	Recoverable bool
-	Err     error
+	Err         error
 }
 
 func (e *TransactionError) Error() string {
@@ -14,6 +19,22 @@ func (e *TransactionError) Error() string {
 func NewTransactionError(err error, recoverable bool) error {
 	return &TransactionError{
 		Recoverable: recoverable,
-		Err:     err,
+		Err:         err,
 	}
+}
+
+var ErrLookup = errors.New("target lookup error")
+
+var TargetLookupErr *LookupError
+
+type LookupError struct {
+	Message      string
+	WrappedError error
+}
+
+func (e *LookupError) Error() string {
+	if e.WrappedError != nil {
+		return fmt.Sprintf("%s, err: %s", e.Message, e.WrappedError.Error())
+	}
+	return e.Message
 }

--- a/pkg/target/handler.go
+++ b/pkg/target/handler.go
@@ -61,7 +61,7 @@ func (r *targetHandler) GetTargetContext(ctx context.Context, targetKey types.Na
 			WrappedError: errors.Join(ErrLookup, err),
 		}
 	}
-	if !target.IsReady() {
+	if !target.IsDatastoreReady() {
 		return nil, nil, &sdcerrors.RecoverableError{
 			Message:      "target not ready",
 			WrappedError: pkgerrors.Wrap(ErrLookup, string(config.ConditionReasonTargetNotReady)),

--- a/pkg/target/handler.go
+++ b/pkg/target/handler.go
@@ -19,6 +19,7 @@ package target
 import (
 	"context"
 	errors "errors"
+	"fmt"
 
 	"github.com/henderiw/apiserver-store/pkg/storebackend"
 	pkgerrors "github.com/pkg/errors"
@@ -70,7 +71,7 @@ func (r *targetHandler) GetTargetContext(ctx context.Context, targetKey types.Na
 	tctx, err := r.targetStore.Get(ctx, storebackend.Key{NamespacedName: targetKey})
 	if err != nil {
 		return nil, nil, &sdcerrors.RecoverableError{
-			Message:      "target not found",
+			Message:      fmt.Sprintf("target %s not found ", targetKey.String()),
 			WrappedError: pkgerrors.Wrap(ErrLookup, string(config.ConditionReasonTargetNotFound)),
 		}
 	}

--- a/pkg/target/handler.go
+++ b/pkg/target/handler.go
@@ -54,6 +54,7 @@ type targetHandler struct {
 }
 
 // GetTargetContext returns a invTarget and targetContext when the target is ready and the ctx is found
+// Used by the config controller and should only act when the Config is ready
 func (r *targetHandler) GetTargetContext(ctx context.Context, targetKey types.NamespacedName) (*invv1alpha1.Target, *Context, error) {
 	target := &invv1alpha1.Target{}
 	if err := r.client.Get(ctx, targetKey, target); err != nil {
@@ -62,7 +63,8 @@ func (r *targetHandler) GetTargetContext(ctx context.Context, targetKey types.Na
 			WrappedError: errors.Join(ErrLookup, err),
 		}
 	}
-	if !target.IsDatastoreReady() {
+	// A config snippet should only be applied if the Target is in ready state
+	if !target.IsReady() {
 		return nil, nil, &sdcerrors.RecoverableError{
 			Message:      fmt.Sprintf("target %s not ready ", targetKey.String()),
 			WrappedError: pkgerrors.Wrap(ErrLookup, string(config.ConditionReasonTargetNotReady)),

--- a/pkg/target/handler.go
+++ b/pkg/target/handler.go
@@ -29,8 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ErrLookup = errors.New("target lookup error")
-
 type TargetHandler interface {
 	GetTargetContext(ctx context.Context, targetKey types.NamespacedName) (*invv1alpha1.Target, *Context, error)
 	SetIntent(ctx context.Context, targetKey types.NamespacedName, config *config.Config, dryRun bool) (*config.ConfigStatusLastKnownGoodSchema, string, error)

--- a/pkg/target/handler.go
+++ b/pkg/target/handler.go
@@ -58,20 +58,20 @@ func (r *targetHandler) GetTargetContext(ctx context.Context, targetKey types.Na
 	target := &invv1alpha1.Target{}
 	if err := r.client.Get(ctx, targetKey, target); err != nil {
 		return nil, nil, &sdcerrors.RecoverableError{
-			Message:      "target get failed",
+			Message:      fmt.Sprintf("target %s get failed to k8s apiserver ", targetKey.String()),
 			WrappedError: errors.Join(ErrLookup, err),
 		}
 	}
 	if !target.IsDatastoreReady() {
 		return nil, nil, &sdcerrors.RecoverableError{
-			Message:      "target not ready",
+			Message:      fmt.Sprintf("target %s not ready ", targetKey.String()),
 			WrappedError: pkgerrors.Wrap(ErrLookup, string(config.ConditionReasonTargetNotReady)),
 		}
 	}
 	tctx, err := r.targetStore.Get(ctx, storebackend.Key{NamespacedName: targetKey})
 	if err != nil {
 		return nil, nil, &sdcerrors.RecoverableError{
-			Message:      fmt.Sprintf("target %s not found ", targetKey.String()),
+			Message:      fmt.Sprintf("target %s not found in target datastore", targetKey.String()),
 			WrappedError: pkgerrors.Wrap(ErrLookup, string(config.ConditionReasonTargetNotFound)),
 		}
 	}


### PR DESCRIPTION
When the data server is down or target is unavailable and we delete the config resource we were not checking the correct error. Fixed the error checking for target lookup error.
When target is unavailable due to target resource not found, target not ready or data server not available, we delete the config anyhow.