### PR TITLE
Ensure always one metric available on target metric page

### DIFF
--- a/pkg/output/prometheusserver/handler_prometheus.go
+++ b/pkg/output/prometheusserver/handler_prometheus.go
@@ -43,6 +43,19 @@ func (r *PrometheusServer) Collect(ch chan<- prometheus.Metric) {
 	log.Info("prometheus collect")
 
 	wg1 := new(sync.WaitGroup)
+
+	nKeys := len(keys)
+	targetMetricsAvailable := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sdcio_target_metrics_available",
+		Help: "1.0 means at least one target metric is available while 0.0 means no target metrics to export. Ensure subscriptions are declaired to export target metrics as documented on https://docs.sdcio.dev/user-guide/configuration/subscription/subscription/ .",
+	})
+	if nKeys <= 0 {
+		targetMetricsAvailable.Set(0.0)
+	} else {
+		targetMetricsAvailable.Set(1.0)
+	}
+	ch <- targetMetricsAvailable
+
 	wg1.Add(len(keys))
 	for _, key := range keys {
 		go func(key storebackend.Key) {


### PR DESCRIPTION
This MR introduces the `sdcio_target_metrics_available` metric on the target metrics page.

**Background and details:**

When no targets are configured the target metrics page (available on port 9443) returns an empty page with return code 200.

While there is technically nothing wrong with this it can lead to confiusion. Having at least always one metrica available allows us:
* To directly see if metrics are exported and distinguish between network, svc... errors and configuration errors.
* To display a hint where to find further information for correct metric export activation.
* Allows us the setup the service montor and test the full chain with at least an available metric.