### PR TITLE
cleanup: gitignore and makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ scripts/
 kubeconfig
 tls.crt
 tls.key
+
+# IDE specific configuration
+.vscode/
+
+# goreleaser build directories
+dist/


### PR DESCRIPTION
This MR provides some small cleanups:
- `.gitignore`: Ignore IDE files of VSCode and files generated by goreleaser
- `Makefile`: Use `.PHONY` for all targets in a consistent way.