### PR TITLE
fix: Remove gNMI namespace prefix from paths used in notifications

### DIFF
--- a/pkg/discovery/discoveryrule/discover_gnmi.go
+++ b/pkg/discovery/discoveryrule/discover_gnmi.go
@@ -222,6 +222,12 @@ func (r *Discoverer) parseDiscoveryInformation(
 		for _, upd := range notif.GetUpdate() {
 			gnmiPath := GnmiPathToXPath(upd.GetPath(), true)
 
+			// the device returns the path without namespaces
+			if len(strings.Split(gnmiPath, ":")) > 1 {
+				// remove prefix
+				gnmiPath = strings.Join(strings.Split(gnmiPath, ":")[1:], ":")
+			}
+
 			log.Info("discovery", "path", gnmiPath)
 
 			// SRLINUX a path that was requested without keys is returned as a JSON blob up to the first element


### PR DESCRIPTION
I encountered an issue when trying the project with Cisco XRd devices, and that small patch resolves the problem.

In Discovery phase, I had to add paths from different namespaces, and so I used the notation `namespace:path` in the `DiscoveryVendorProfile` resource. The paths were forwarded correctly to the device, but there was a problem in the parsing of the responses because the device replies with only the path, without the namespace.

This is why I added this small piece of code that removes the namespace for checking the informations.