### PR TITLE
add golang linter action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Go Checks
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.4


### PR DESCRIPTION
As we discussed, I added a generic golangci-lint GitHub action with the latest available versions.
Currently, it uses the default configuration. More information [here](https://golangci-lint.run/docs/configuration/file/). I think this is appropriate, but it can be modified if desired.
The pipeline is triggered as soon as a PR is created towards the main branch. I had good experiences using the setup. 
Please review/test that setup and merge them if they look good to you.
Resolves #355 


Cheers,
Severin