### PR TITLE
fix nil dereference panic 

### DIFF
--- a/pkg/sdc/schemaserver/client/client.go
+++ b/pkg/sdc/schemaserver/client/client.go
@@ -113,7 +113,7 @@ func (r *client) Start(ctx context.Context) error {
         }
         if !conn.WaitForStateChange(dialCtx, s) {
             // context expired or canceled
-            if err := r.conn.Close(); err != nil {
+            if err := conn.Close(); err != nil {
 				log.Error("close error", "err", err)
 			}
             return fmt.Errorf("gRPC connect timeout; last state: %s", s.String())


### PR DESCRIPTION
when connection takes too long for schemaserver client, a panic was raised because Stop was being called on a nil pointer (r.conn was not yet set)