### PR TITLE
add groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 version: 2
 updates:
-  -   package-ecosystem: "github-actions"
+    - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
           interval: "weekly"
-  -   package-ecosystem: "gomod"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"
+
+    - package-ecosystem: "gomod"
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          go-dependencies:
+              patterns:
+                  - "*"


### PR DESCRIPTION
This PR causes dependabot to create one PR per dependency group, instead of one PR per dependency