### PR TITLE
Optimized Network Policy for config-server

### DIFF
--- a/artifacts/allow-metrics-traffic.yaml
+++ b/artifacts/allow-metrics-traffic.yaml
@@ -1,11 +1,8 @@
 # This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gathering data from the metrics endpoint.
+# with Pods running in the monitoring namespaces.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  labels:
-    app.kubernetes.io/name: config-server
   name: allow-metrics-traffic
   namespace: network-system
 spec:
@@ -15,11 +12,13 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # This allows ingress traffic from any pod within the monitoring namespace on port 8443
     - from:
-      - namespaceSelector:
-          matchLabels:
-            metrics: enabled  # Only from namespaces with this label
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring # Select namespace with name monitoring
       ports:
         - port: 8443
           protocol: TCP
+    - from:
+        - podSelector: {}


### PR DESCRIPTION
I optimized the network policy to allow:
- all traffic from other pods within the same namespace (network-system)
- TCP traffic on port 8443 from all pods in the monitoring namespace

The proposed changes align with the documentation that describes the creation of the monitoring namespace and the deployment of Prometheus instances.

Please review the changes and merge them if they look good to you.
