### PR TITLE
fix(dryrun): resolve Target from label not Config name

### DIFF
--- a/.github/workflows/dev-nightlies.yml
+++ b/.github/workflows/dev-nightlies.yml
@@ -43,7 +43,10 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean -f .goreleaser.nightlies.yml --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PR: "false"
+          PR: ""
+          MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}

--- a/.github/workflows/dev-nightlies.yml
+++ b/.github/workflows/dev-nightlies.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       # Make sure the @v0.8.0 matches the current version of the action
       - uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       # Make sure the @v0.8.0 matches the current version of the action
       - uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean -f .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,15 @@ jobs:
           PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
+      # Nightlies publish {{ .Commit }} as a tag (see .goreleaser.nightlies.yml); same string is the git ref for checkout.
       - name: Set image tag for integration tests
         id: image
         run: |
-          echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "version=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
 
   latest-versions:
     name: Fetch latest versions from GH API

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,11 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           fetch-depth: 0
+          fetch-tags: true
 
-      - name: Fetch upstream tags
+      # Fork clones lack canonical release tags; GoReleaser still resolves {{.Version}} from git.
+      - name: Fetch upstream tags (fork PRs only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           git fetch --force --tags https://github.com/${{ github.repository }}.git '+refs/tags/*:refs/tags/*'
 
@@ -68,18 +71,10 @@ jobs:
           PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
-      # Must match image tags in .goreleaser.nightlies.yml (IS_PR / MAIN_BRANCH / ShortCommit).
       - name: Set image tag for integration tests
         id: image
         run: |
-          short=$(git rev-parse --short HEAD)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "version=v0.0.0-PR${{ github.event.pull_request.number }}-${short}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "version=main" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=v0.0.0-${short}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   latest-versions:
     name: Fetch latest versions from GH API

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,13 @@
 # Licensed under the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: Test
+name: CI/CD (PR and main)
 on:
   workflow_dispatch:
   pull_request:
-  pull_request_target:
-    types: [labeled]
   push:
     branches:
-      - "main"
+      - main
       - "!releases/**"
 
 permissions:
@@ -21,25 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - run: go test -cover ./...
         env:
           CGO_ENABLED: 0
-      # run staticcheck
-      # - uses: reviewdog/action-staticcheck@v1
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
-      #     reporter: github-pr-review
-      #     # Report all results.
-      #     filter_mode: nofilter
-      #     # Exit with 1 when it find at least one finding.
-      #     fail_on_error: true
+
   pr-release:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     runs-on: ubuntu-latest
     needs: unittest
     outputs:
@@ -48,9 +36,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           fetch-depth: 0
+
+      - name: Fetch upstream tags
+        run: |
+          git fetch --force --tags https://github.com/${{ github.repository }}.git '+refs/tags/*:refs/tags/*'
 
       - uses: actions/setup-go@v6
         with:
@@ -67,18 +59,19 @@ jobs:
         id: goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean -f .goreleaser.nightlies.yml --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
+          IS_PR: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
       - name: Extract docker image build version from GoReleaser
         id: image
         run: |
-          echo "version=$( echo '${{ steps.goreleaser.outputs.artifacts }}' | jq -r 'limit(1; .[] | select(.type == "Published Docker Image" and (.name | contains("ghcr.io")) and (.name | contains("latest") | not))) | .name | split(":") | .[1]' )" >> $GITHUB_OUTPUT
+          echo "version=$( echo '${{ steps.goreleaser.outputs.artifacts }}' | jq -r '[.[] | select(.type == "Published Docker Image" and (.name | contains("ghcr.io")) and (.name | contains("latest") | not)) | .name | split(":") | last] | unique | (map(select(. == "main")) | first) // first' )" >> $GITHUB_OUTPUT
 
   latest-versions:
     name: Fetch latest versions from GH API

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,10 +68,10 @@ jobs:
           PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
-      - name: Extract docker image build version from GoReleaser
+      - name: Set image tag for integration tests
         id: image
         run: |
-          echo "version=$( echo '${{ steps.goreleaser.outputs.artifacts }}' | jq -r '[.[] | select(.type == "Published Docker Image" and (.name | contains("ghcr.io")) and (.name | contains("latest") | not)) | .name | split(":") | last] | unique | (map(select(. == "main")) | first) // first' )" >> $GITHUB_OUTPUT
+          echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   latest-versions:
     name: Fetch latest versions from GH API

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,10 +68,18 @@ jobs:
           PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
           MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
+      # Must match image tags in .goreleaser.nightlies.yml (IS_PR / MAIN_BRANCH / ShortCommit).
       - name: Set image tag for integration tests
         id: image
         run: |
-          echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          short=$(git rev-parse --short HEAD)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "version=v0.0.0-PR${{ github.event.pull_request.number }}-${short}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "version=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=v0.0.0-${short}" >> "$GITHUB_OUTPUT"
+          fi
 
   latest-versions:
     name: Fetch latest versions from GH API

--- a/.goreleaser.nightlies.yml
+++ b/.goreleaser.nightlies.yml
@@ -2,7 +2,7 @@ version: 2
 project_name: config-server
 builds:
   - id: api-server
-    binary:  api-server
+    binary: api-server
     main: ./cmd/api-server/main.go
     env:
       - CGO_ENABLED=0
@@ -21,38 +21,52 @@ builds:
     goarch:
       - amd64
       - arm64
-dockers:
+dockers_v2:
   - id: api-server-docker
-    goos: linux
-    goarch: amd64
     ids:
       - api-server
-    image_templates:
-      - "ghcr.io/sdcio/{{ .ProjectName }}-api-server:v0.0.0-{{ if index .Env \"PR\"  }}PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}{{ .ShortCommit }}{{ end }}"
     dockerfile: goreleaser.api-server.dockerfile
-    skip_push: false
-    build_flag_templates:
-      - "--pull"
-      - "--build-arg=USERID=10000"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-api-server"
-      - "--label=org.opencontainers.image.source=https://github.com/sdcio/{{.ProjectName}}"
-      - "--label=org.opencontainers.image.version=v{{.Version}}"
+    images:
+      - ghcr.io/sdcio/config-server-api-server
+    tags:
+      # Primary: PR → v0.0.0-PR<n>-<shortsha>. Main → main. Else → v0.0.0-<shortsha>.
+      - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+      # Secondary (main only): immutable v0.0.0-<shortsha>; other builds repeat the primary tag (harmless duplicate).
+      - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+    platforms:
+      - linux/amd64
+    sbom: false
+    flags:
+      - "--pull=true"
+      - "--provenance=false"
+    build_args:
+      USERID: "10000"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}-api-server"
+      org.opencontainers.image.source: "https://github.com/sdcio/{{.ProjectName}}"
+      org.opencontainers.image.version: "v{{.Version}}"
   - id: controller-docker
-    goos: linux
-    goarch: amd64
     ids:
       - controller
-    image_templates:
-      - "ghcr.io/sdcio/{{ .ProjectName }}-controller:v0.0.0-{{ if index .Env \"PR\"  }}PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}{{ .ShortCommit }}{{ end }}"
     dockerfile: goreleaser.controller.dockerfile
-    skip_push: false
-    build_flag_templates:
-      - "--pull"
-      - "--build-arg=USERID=10000"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-controller"
-      - "--label=org.opencontainers.image.source=https://github.com/sdcio/{{.ProjectName}}"
-      - "--label=org.opencontainers.image.version=v{{.Version}}"
+    images:
+      - ghcr.io/sdcio/config-server-controller
+    tags:
+      - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+      - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+    platforms:
+      - linux/amd64
+    sbom: false
+    flags:
+      - "--pull=true"
+      - "--provenance=false"
+    build_args:
+      USERID: "10000"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}-controller"
+      org.opencontainers.image.source: "https://github.com/sdcio/{{.ProjectName}}"
+      org.opencontainers.image.version: "v{{.Version}}"
 release:
   disable: true

--- a/.goreleaser.nightlies.yml
+++ b/.goreleaser.nightlies.yml
@@ -33,7 +33,8 @@ dockers_v2:
       - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
       # Secondary (main only): immutable v0.0.0-<shortsha>; other builds repeat the primary tag (harmless duplicate).
       - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
-      - "{{ .ShortCommit }}"
+      # Extra alias: full git SHA only (unambiguous ref); primary tags above still use ShortCommit.
+      - "{{ .Commit }}"
     platforms:
       - linux/amd64
     sbom: false
@@ -56,7 +57,8 @@ dockers_v2:
     tags:
       - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
       - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
-      - "{{ .ShortCommit }}"
+      # Extra alias: full git SHA only (unambiguous ref); primary tags above still use ShortCommit.
+      - "{{ .Commit }}"
     platforms:
       - linux/amd64
     sbom: false

--- a/.goreleaser.nightlies.yml
+++ b/.goreleaser.nightlies.yml
@@ -33,6 +33,7 @@ dockers_v2:
       - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
       # Secondary (main only): immutable v0.0.0-<shortsha>; other builds repeat the primary tag (harmless duplicate).
       - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+      - "{{ .ShortCommit }}"
     platforms:
       - linux/amd64
     sbom: false
@@ -55,6 +56,7 @@ dockers_v2:
     tags:
       - '{{ if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else if eq .Env.MAIN_BRANCH "true" }}main{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
       - '{{ if eq .Env.MAIN_BRANCH "true" }}v0.0.0-{{ .ShortCommit }}{{ else if eq .Env.IS_PR "true" }}v0.0.0-PR{{ .Env.PR }}-{{ .ShortCommit }}{{ else }}v0.0.0-{{ .ShortCommit }}{{ end }}'
+      - "{{ .ShortCommit }}"
     platforms:
       - linux/amd64
     sbom: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ version: 2
 project_name: config-server
 builds:
   - id: api-server
-    binary:  api-server
+    binary: api-server
     main: ./cmd/api-server/main.go
     env:
       - CGO_ENABLED=0
@@ -21,41 +21,51 @@ builds:
     goarch:
       - amd64
       - arm64
-dockers:
+dockers_v2:
   - id: api-server-docker
-    goos: linux
-    goarch: amd64
     ids:
       - api-server
-    image_templates:
-      - "ghcr.io/sdcio/{{ .ProjectName }}-api-server:v{{ .Version }}"
-      - "ghcr.io/sdcio/{{ .ProjectName }}-api-server:latest"
     dockerfile: goreleaser.api-server.dockerfile
-    skip_push: false
-    build_flag_templates:
-      - "--pull"
-      - "--build-arg=USERID=10000"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-api-server"
-      - "--label=org.opencontainers.image.source=https://github.com/sdcio/{{.ProjectName}}"
-      - "--label=org.opencontainers.image.version=v{{.Version}}"
+    images:
+      - ghcr.io/sdcio/config-server-api-server
+    tags:
+      - latest
+      - "v{{ .Version }}"
+    platforms:
+      - linux/amd64
+    sbom: false
+    flags:
+      - "--pull=true"
+      - "--provenance=false"
+    build_args:
+      USERID: "10000"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}-api-server"
+      org.opencontainers.image.source: "https://github.com/sdcio/{{.ProjectName}}"
+      org.opencontainers.image.version: "v{{.Version }}"
   - id: controller-docker
-    goos: linux
-    goarch: amd64
     ids:
       - controller
-    image_templates:
-      - "ghcr.io/sdcio/{{ .ProjectName }}-controller:v{{ .Version }}"
-      - "ghcr.io/sdcio/{{ .ProjectName }}-controller:latest"
     dockerfile: goreleaser.controller.dockerfile
-    skip_push: false
-    build_flag_templates:
-      - "--pull"
-      - "--build-arg=USERID=10000"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}-controller"
-      - "--label=org.opencontainers.image.source=https://github.com/sdcio/{{.ProjectName}}"
-      - "--label=org.opencontainers.image.version=v{{.Version}}"
+    images:
+      - ghcr.io/sdcio/config-server-controller
+    tags:
+      - latest
+      - "v{{ .Version }}"
+    platforms:
+      - linux/amd64
+    sbom: false
+    flags:
+      - "--pull=true"
+      - "--provenance=false"
+    build_args:
+      USERID: "10000"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}-controller"
+      org.opencontainers.image.source: "https://github.com/sdcio/{{.ProjectName}}"
+      org.opencontainers.image.version: "v{{.Version }}"
 archives:
   - name_template: >-
       {{ .ProjectName }}_
@@ -69,7 +79,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 changelog:
   use: github
   sort: asc

--- a/apis/config/handlers/confighandler.go
+++ b/apis/config/handlers/confighandler.go
@@ -35,7 +35,7 @@ type ConfigStoreHandler struct {
 }
 
 func (r *ConfigStoreHandler) DryRunCreateFn(ctx context.Context, key types.NamespacedName, obj runtime.Object, dryrun bool) (runtime.Object, error) {
-	c, target, err := r.prepareConfigAndTarget(ctx, key, obj)
+	c, target, err := r.prepareConfigAndTarget(ctx, obj)
 	if err != nil {
 		return obj, err
 	}
@@ -47,17 +47,17 @@ func (r *ConfigStoreHandler) DryRunCreateFn(ctx context.Context, key types.Names
 
 	intents := []*sdcpb.TransactionIntent{
 		{
-			Intent:       config.GetGVKNSN(c),
-			Priority:     int32(c.Spec.Priority),
-			Update:       updates,
+			Intent:   config.GetGVKNSN(c),
+			Priority: int32(c.Spec.Priority),
+			Update:   updates,
 			// Dont set not Revertive
 		},
 	}
 
-	return targetmanager.RunDryRunTransaction(ctx, key, c, target, intents, dryrun)
+	return targetmanager.RunDryRunTransaction(ctx, c, target, intents, dryrun)
 }
 func (r *ConfigStoreHandler) DryRunUpdateFn(ctx context.Context, key types.NamespacedName, obj, old runtime.Object, dryrun bool) (runtime.Object, error) {
-	c, target, err := r.prepareConfigAndTarget(ctx, key, obj)
+	c, target, err := r.prepareConfigAndTarget(ctx, obj)
 	if err != nil {
 		return obj, err
 	}
@@ -69,17 +69,17 @@ func (r *ConfigStoreHandler) DryRunUpdateFn(ctx context.Context, key types.Names
 
 	intents := []*sdcpb.TransactionIntent{
 		{
-			Intent:       config.GetGVKNSN(c),
-			Priority:     int32(c.Spec.Priority),
-			Update:       updates,
+			Intent:   config.GetGVKNSN(c),
+			Priority: int32(c.Spec.Priority),
+			Update:   updates,
 			// Dont set not Revertive
 		},
 	}
 
-	return targetmanager.RunDryRunTransaction(ctx, key, c, target, intents, dryrun)
+	return targetmanager.RunDryRunTransaction(ctx, c, target, intents, dryrun)
 }
 func (r *ConfigStoreHandler) DryRunDeleteFn(ctx context.Context, key types.NamespacedName, obj runtime.Object, dryrun bool) (runtime.Object, error) {
-	c, target, err := r.prepareConfigAndTarget(ctx, key, obj)
+	c, target, err := r.prepareConfigAndTarget(ctx, obj)
 	if err != nil {
 		return obj, err
 	}
@@ -91,14 +91,14 @@ func (r *ConfigStoreHandler) DryRunDeleteFn(ctx context.Context, key types.Names
 		},
 	}
 
-	return targetmanager.RunDryRunTransaction(ctx, key, c, target, intents, dryrun)
+	return targetmanager.RunDryRunTransaction(ctx, c, target, intents, dryrun)
 }
 
-// prepareConfigAndTarget validates labels, casts the object, fetches the Target
-// and ensures it's ready.
+// prepareConfigAndTarget validates labels, casts the object, resolves the
+// Target reference from the config's labels and fetches that Target, ensuring
+// it's ready.
 func (r *ConfigStoreHandler) prepareConfigAndTarget(
 	ctx context.Context,
-	key types.NamespacedName,
 	obj runtime.Object,
 ) (*config.Config, *configv1alpha1.Target, error) {
 	accessor, err := meta.Accessor(obj)
@@ -106,7 +106,8 @@ func (r *ConfigStoreHandler) prepareConfigAndTarget(
 		return nil, nil, err
 	}
 
-	if _, err := config.GetTargetKey(accessor.GetLabels()); err != nil {
+	targetKey, err := config.GetTargetKey(accessor.GetLabels())
+	if err != nil {
 		return nil, nil, err
 	}
 
@@ -116,12 +117,12 @@ func (r *ConfigStoreHandler) prepareConfigAndTarget(
 	}
 
 	target := &configv1alpha1.Target{}
-	if err := r.Client.Get(ctx, key, target); err != nil {
+	if err := r.Client.Get(ctx, targetKey, target); err != nil {
 		return nil, nil, err
 	}
 
 	if !target.IsReady() {
-		return nil, nil, fmt.Errorf("target not ready %s", key)
+		return nil, nil, fmt.Errorf("target not ready %s", targetKey)
 	}
 
 	return c, target, nil

--- a/apis/config/handlers/confighandler.go
+++ b/apis/config/handlers/confighandler.go
@@ -94,13 +94,18 @@ func (r *ConfigStoreHandler) DryRunDeleteFn(ctx context.Context, key types.Names
 	return targetmanager.RunDryRunTransaction(ctx, c, target, intents, dryrun)
 }
 
-// prepareConfigAndTarget validates labels, casts the object, resolves the
+// prepareConfigAndTarget validates labels, resolves the
 // Target reference from the config's labels and fetches that Target, ensuring
 // it's ready.
 func (r *ConfigStoreHandler) prepareConfigAndTarget(
 	ctx context.Context,
 	obj runtime.Object,
 ) (*config.Config, *configv1alpha1.Target, error) {
+	c, ok := obj.(*config.Config)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected *config.Config, got %T", obj)
+	}
+
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, nil, err
@@ -109,11 +114,6 @@ func (r *ConfigStoreHandler) prepareConfigAndTarget(
 	targetKey, err := config.GetTargetKey(accessor.GetLabels())
 	if err != nil {
 		return nil, nil, err
-	}
-
-	c, ok := obj.(*config.Config)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected *config.Config, got %T", obj)
 	}
 
 	target := &configv1alpha1.Target{}

--- a/goreleaser.api-server.dockerfile
+++ b/goreleaser.api-server.dockerfile
@@ -18,6 +18,8 @@ RUN adduser --shell /bin/false --uid $USERID --disabled-login --home /app/ --no-
 #
 #FROM scratch
 FROM alpine:latest
+# GoReleaser dockers_v2 places pre-built binaries under $TARGETPLATFORM/ in the build context.
+ARG TARGETPLATFORM
 ARG USERID=10000
 # add-in our timezone data file
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
@@ -26,7 +28,7 @@ COPY --from=builder /etc/passwd /etc/group /etc/shadow /etc/
 # add-in our ca certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY --chown=$USERID:$USERID api-server /app/
+COPY --chown=$USERID:$USERID ${TARGETPLATFORM}/api-server /app/api-server
 WORKDIR /app
 
 # from now on, run as the unprivileged user

--- a/goreleaser.controller.dockerfile
+++ b/goreleaser.controller.dockerfile
@@ -18,6 +18,8 @@ RUN adduser --shell /bin/false --uid $USERID --disabled-login --home /app/ --no-
 #
 #FROM scratch
 FROM alpine:latest
+# GoReleaser dockers_v2 places pre-built binaries under $TARGETPLATFORM/ in the build context.
+ARG TARGETPLATFORM
 ARG USERID=10000
 # add-in our timezone data file
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
@@ -26,7 +28,7 @@ COPY --from=builder /etc/passwd /etc/group /etc/shadow /etc/
 # add-in our ca certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY --chown=$USERID:$USERID controller /app/
+COPY --chown=$USERID:$USERID ${TARGETPLATFORM}/controller /app/controller
 WORKDIR /app
 
 # from now on, run as the unprivileged user

--- a/pkg/sdc/target/manager/dryrun.go
+++ b/pkg/sdc/target/manager/dryrun.go
@@ -57,10 +57,11 @@ func RunDryRunTransaction(
 		}
 	}()
 
-	targetKey := types.NamespacedName{Namespace: target.Namespace, Name: target.Name}
+	targetKey := storebackend.KeyFromNSN(target.GetNamespacedName())
+
 	req := &sdcpb.TransactionSetRequest{
 		TransactionId: config.GetGVKNSN(c),
-		DatastoreName: storebackend.KeyFromNSN(targetKey).String(),
+		DatastoreName: targetKey.String(),
 		DryRun:        dryrun,
 		Timeout:       ptr.To(int32(60)),
 		Intents:       intents,

--- a/pkg/sdc/target/manager/dryrun.go
+++ b/pkg/sdc/target/manager/dryrun.go
@@ -27,7 +27,6 @@ import (
 	dsclient "github.com/sdcio/config-server/pkg/sdc/dataserver/client"
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 

--- a/pkg/sdc/target/manager/dryrun.go
+++ b/pkg/sdc/target/manager/dryrun.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/henderiw/apiserver-store/pkg/storebackend"
 	"github.com/sdcio/config-server/apis/condition"
 	"github.com/sdcio/config-server/apis/config"
 	configv1alpha1 "github.com/sdcio/config-server/apis/config/v1alpha1"
@@ -35,7 +36,6 @@ import (
 // and updates the Config status/conditions.
 func RunDryRunTransaction(
 	ctx context.Context,
-	key types.NamespacedName,
 	c *config.Config,
 	target *configv1alpha1.Target,
 	intents []*sdcpb.TransactionIntent,
@@ -57,9 +57,10 @@ func RunDryRunTransaction(
 		}
 	}()
 
+	targetKey := types.NamespacedName{Namespace: target.Namespace, Name: target.Name}
 	req := &sdcpb.TransactionSetRequest{
 		TransactionId: config.GetGVKNSN(c),
-		DatastoreName: key.String(),
+		DatastoreName: storebackend.KeyFromNSN(targetKey).String(),
 		DryRun:        dryrun,
 		Timeout:       ptr.To(int32(60)),
 		Intents:       intents,


### PR DESCRIPTION
## Summary

`--dry-run=server` against a `Config` whose name differs from its target's name failed with:
```
Internal error occurred: Target.config.sdcio.dev "<config namespace.name>" not found
```

The dry-run path in `ConfigStoreHandler.prepareConfigAndTarget` discarded the
`NamespacedName` returned by `config.GetTargetKey(labels)` and looked up the
`Target` using the `Config`'s own key instead. The same wrong key was then
propagated as the `DatastoreName` in the `TransactionSet` RPC.

Non-dry-run applies were unaffected because the API server only persists the
`Config` and the actual target resolution happens later in the reconcilers,
which correctly read `config.sdcio.dev/targetName` / `targetNamespace` from
the labels.

## Changes

- Use the label-derived `targetKey` for the `Target` lookup in
  `prepareConfigAndTarget`.
- Drop the unused `key types.NamespacedName` parameter from
  `RunDryRunTransaction`; derive `DatastoreName` from the resolved `*Target`
  using `storebackend.KeyFromNSN(...).String()`, matching the convention used
  by every other call site (`pkg/reconcilers/rollout/transaction.go`,
  `apis/config/target_helpers.go`, `pkg/reconcilers/targetdatastore/reconciler.go`,
  etc.). The previous `types.NamespacedName.String()` ("ns/name") did not match
  the format the datastore is registered under ("ns.name").