### PR TITLE
fix DeviationName for get

### DIFF
--- a/artifacts/in/configmap-input-vars.yaml
+++ b/artifacts/in/configmap-input-vars.yaml
@@ -5,5 +5,5 @@ metadata:
 data: 
   sdcApiServerImage: europe-docker.pkg.dev/srlinux/eu.gcr.io/sdc-apiserver:latest
   sdcControllerImage: europe-docker.pkg.dev/srlinux/eu.gcr.io/sdc-controller:latest
-  dataServerImage: ghcr.io/sdcio/data-server:v0.0.67
+  dataServerImage: ghcr.io/sdcio/data-server:v0.0.68
 

--- a/pkg/sdc/target/manager/transactor.go
+++ b/pkg/sdc/target/manager/transactor.go
@@ -519,7 +519,7 @@ func (r *Transactor) ListConfigsPerTarget(ctx context.Context, target *configv1a
 
 func (r *Transactor) applyDeviation(ctx context.Context, config *config.Config) (configv1alpha1.Deviation, error) {
 	key := types.NamespacedName{
-		Name:      config.Name,
+		Name:      configv1alpha1.DeviationName(configv1alpha1.DeviationType_CONFIG, config.Name),
 		Namespace: config.Namespace,
 	}
 


### PR DESCRIPTION
Currently in main we get an issue with deviation reapply. The DeviationName for the get was not correct for retrieving the resource. The prefix was not applied correctly

{"time":"2026-05-21T13:50:44.24043299Z","level":"WARN","message":"config transaction failed","logger":"sdc-controller-logger","data":{"controller":"TargetConfigController","req":{"Namespace":"default","Name":"sr1"},"retry":true,"error":{"message":"Internal error occurred: Internal error occurred: AlreadyExists","stack":["/home/runner/go/pkg/mod/github.com/henderiw/logger@v0.0.0-20230911123436-8655829b1abe/log/handler.go:34 (github.com/henderiw/logger/log.(*Handler).Handle)","/home/runner/work/config-server/config-server/pkg/reconcilers/targetconfig/reconciler.go:210 (github.com/sdcio/config-server/pkg/reconcilers/targetconfig.(*reconciler).Reconcile)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1)","/opt/hostedtoolcache/go/1.25.0/x64/src/runtime/asm_amd64.s:1693 (runtime.goexit)"]}}}
{"time":"2026-05-21T13:50:44.24076407Z","level":"WARN","message":"config transaction failed","logger":"sdc-controller-logger","data":{"controller":"TargetConfigController","req":{"Namespace":"default","Name":"sr1"},"message":"\"\" err \"Internal error occurred: Internal error occurred: AlreadyExists\"","error":{"message":"Internal error occurred: Internal error occurred: AlreadyExists","stack":["/home/runner/go/pkg/mod/github.com/henderiw/logger@v0.0.0-20230911123436-8655829b1abe/log/handler.go:34 (github.com/henderiw/logger/log.(*Handler).Handle)","/home/runner/work/config-server/config-server/pkg/reconcilers/targetconfig/reconciler.go:270 (github.com/sdcio/config-server/pkg/reconcilers/targetconfig.(*reconciler).handleError)","/home/runner/work/config-server/config-server/pkg/reconcilers/targetconfig/reconciler.go:223 (github.com/sdcio/config-server/pkg/reconcilers/targetconfig.(*reconciler).Reconcile)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem)","/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313 (sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1)","/opt/hostedtoolcache/go/1.25.0/x64/src/runtime/asm_amd64.s:1693 (runtime.goexit)"]}}}
{"time":"2026-05-21T13:50:44.296218578Z","level":"INFO","message":"config transaction success","logger":"sdc-controller-logger","data":{"controller":"TargetConfigController","req":{"Namespace":"default","Name":"sr2"},"retry":false}}
{"time":"2026-05-21T13:50:44.303805302Z","level":"INFO","message":"reconcile","logger":"sdc-controller-logger","data":{"controller":"TargetConfigController","req":{"Namespace":"default","Name":"sr2"}}}