### PR TITLE
fix(cleardeviation): reject invalid requests and accept Deviation CR names

### DIFF
--- a/apis/config/deviation_helper.go
+++ b/apis/config/deviation_helper.go
@@ -17,12 +17,34 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sdcio/config-server/apis/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// DeviationName returns the canonical name for a Deviation CR.
+// The convention is "<type>-<resourceName>" so that config and target
+// deviations cannot collide on the same name (see issue #437).
+func DeviationName(typ DeviationType, resourceName string) string {
+	return fmt.Sprintf("%s-%s", typ, resourceName)
+}
+
+// ParseDeviationName is the inverse of DeviationName. It returns the parsed
+// DeviationType and underlying resource name if name matches the
+// "<type>-<resourceName>" convention. ok is false when the prefix doesn't
+// match a known DeviationType.
+func ParseDeviationName(name string) (DeviationType, string, bool) {
+	for _, typ := range []DeviationType{DeviationType_CONFIG, DeviationType_TARGET} {
+		prefix := string(typ) + "-"
+		if rest, found := strings.CutPrefix(name, prefix); found && rest != "" {
+			return typ, rest, true
+		}
+	}
+	return "", "", false
+}
 
 // GetCondition returns the condition based on the condition kind
 func (r *Deviation) GetCondition(t condition.ConditionType) condition.Condition {

--- a/apis/config/deviation_helper_test.go
+++ b/apis/config/deviation_helper_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Nokia.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "testing"
+
+func TestDeviationName(t *testing.T) {
+	cases := map[string]struct {
+		typ      DeviationType
+		resource string
+		want     string
+	}{
+		"config": {DeviationType_CONFIG, "intent1-srl-srl1", "config-intent1-srl-srl1"},
+		"target": {DeviationType_TARGET, "srl1", "target-srl1"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := DeviationName(tc.typ, tc.resource); got != tc.want {
+				t.Fatalf("DeviationName(%q, %q) = %q, want %q", tc.typ, tc.resource, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDeviationName(t *testing.T) {
+	cases := map[string]struct {
+		input        string
+		wantType     DeviationType
+		wantResource string
+		wantOK       bool
+	}{
+		"config prefixed": {"config-intent1-srl-srl1", DeviationType_CONFIG, "intent1-srl-srl1", true},
+		"target prefixed": {"target-srl1", DeviationType_TARGET, "srl1", true},
+		// legacy CRs predate the prefix; ok=false so callers keep the raw name
+		"no known prefix": {"intent1-srl-srl1", "", "", false},
+		// strip only the leading prefix even when the resource itself begins with one
+		"resource name starts with prefix literal": {"config-config-name", DeviationType_CONFIG, "config-name", true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			typ, resource, ok := ParseDeviationName(tc.input)
+			if ok != tc.wantOK || typ != tc.wantType || resource != tc.wantResource {
+				t.Fatalf("ParseDeviationName(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.input, typ, resource, ok, tc.wantType, tc.wantResource, tc.wantOK)
+			}
+		})
+	}
+}

--- a/apis/config/target_cleardeviation_test.go
+++ b/apis/config/target_cleardeviation_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 Nokia.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestResolveClearDeviationConfig(t *testing.T) {
+	cfg := &Config{}
+	cfg.Name = "intent1-srl-srl1"
+
+	configs := map[string]*Config{cfg.Name: cfg}
+	targetKey := types.NamespacedName{Namespace: "default", Name: "srl1"}
+
+	cases := map[string]struct {
+		input        string
+		wantCfg      *Config
+		wantErrMatch string
+	}{
+		"exact match by config name":     {"intent1-srl-srl1", cfg, ""},
+		"match via deviation prefix":     {"config-intent1-srl-srl1", cfg, ""},
+		"unknown name":                   {"missing", nil, "not found"},
+		"unknown after prefix strip":     {"config-missing", nil, "not found"},
+		"target-typed deviation rejects": {"target-srl1", nil, "target-scoped"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := resolveClearDeviationConfig(tc.input, configs, targetKey)
+			if tc.wantErrMatch != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrMatch) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrMatch, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantCfg {
+				t.Fatalf("got %v, want %v", got, tc.wantCfg)
+			}
+		})
+	}
+}

--- a/apis/config/target_helpers.go
+++ b/apis/config/target_helpers.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/henderiw/apiserver-store/pkg/storebackend"
@@ -30,7 +31,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -240,16 +243,15 @@ func (r *Target) ClearDeviations(ctx context.Context, c client.Client, req *Targ
 		return nil, err
 	}
 
-	// Build the learDeviationTxRequest
+	// any invalid entry in the batch will be rejected with 422 so the failure can't be masked by
+	// a status-code-only client. If the batch is valid, the transaction will be executed.
 	txReq, validationErrors := buildClearDeviationTxRequest(targetKey, spec, configsByName)
 	if len(validationErrors) > 0 {
-		return &TargetClearDeviation{
-			ObjectMeta: metav1.ObjectMeta{Name: r.Name, Namespace: r.Namespace},
-			Status: &TargetClearDeviationStatus{
-				Message: "validation failed: unknown config names",
-				Results: validationErrors,
-			},
-		}, nil
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: GroupName, Kind: TargetClearDeviationKind},
+			r.Name,
+			validationErrorsToFieldErrors(validationErrors),
+		)
 	}
 	if len(txReq.Intents) == 0 {
 		return &TargetClearDeviation{
@@ -260,19 +262,16 @@ func (r *Target) ClearDeviations(ctx context.Context, c client.Client, req *Targ
 		}, nil
 	}
 
-	// Execute the transaction
 	rsp, txErr := executeClearDeviationTx(ctx, txReq)
-
-	// Build the response
+	status := buildClearDeviationStatus(spec.Config, configsByName, rsp, txErr)
 	return &TargetClearDeviation{
 		ObjectMeta: metav1.ObjectMeta{Name: r.Name, Namespace: r.Namespace},
-		Status:     buildClearDeviationStatus(spec.Config, configsByName, rsp, txErr),
+		Status:     status,
 	}, nil
 }
 
-// buildClearDeviationTxRequest constructs the TransactionSetRequest from
-// the clear deviation configs. It validates that every requested config name
-// exists as a known intent. Unknown names are returned as validation errors.
+// buildClearDeviationTxRequest validates each entry, builds the transaction
+// intents for the valid ones, and returns the rejected entries separately
 func buildClearDeviationTxRequest(
 	targetKey types.NamespacedName,
 	spec *TargetClearDeviationSpec,
@@ -282,12 +281,12 @@ func buildClearDeviationTxRequest(
 	var validationErrors []TargetClearDeviationConfigResult
 	intents := make([]*sdcpb.TransactionIntent, 0, len(spec.Config))
 	for _, clearCfg := range spec.Config {
-		cfg, found := configsByName[clearCfg.Name]
-		if !found {
+		cfg, lookupErr := resolveClearDeviationConfig(clearCfg.Name, configsByName, targetKey)
+		if lookupErr != nil {
 			validationErrors = append(validationErrors, TargetClearDeviationConfigResult{
 				Name:    clearCfg.Name,
 				Success: false,
-				Errors:  []string{fmt.Sprintf("config %q not found for target %s", clearCfg.Name, targetKey.Name)},
+				Errors:  []string{lookupErr.Error()},
 			})
 			continue
 		}
@@ -339,9 +338,8 @@ func buildClearDeviationTxRequest(
 		})
 	}
 
-	// Early exit on validation errors
-	if len(validationErrors) > 0 {
-		return nil, validationErrors
+	if len(intents) == 0 {
+		return &sdcpb.TransactionSetRequest{}, validationErrors
 	}
 
 	return &sdcpb.TransactionSetRequest{
@@ -350,7 +348,55 @@ func buildClearDeviationTxRequest(
 		DryRun:        false,
 		Timeout:       ptr.To(int32(60)),
 		Intents:       intents,
-	}, nil
+	}, validationErrors
+}
+
+// resolveClearDeviationConfig looks up a Config CR by either its own name
+// or by a Deviation CR name produced by DeviationName. Target-typed
+// deviation names are rejected because clearing target deviations is not
+// implemented on this path.
+func resolveClearDeviationConfig(
+	name string,
+	configsByName map[string]*Config,
+	targetKey types.NamespacedName,
+) (*Config, error) {
+	if cfg, ok := configsByName[name]; ok {
+		return cfg, nil
+	}
+	if typ, resource, ok := ParseDeviationName(name); ok {
+		switch typ {
+		case DeviationType_TARGET:
+			return nil, fmt.Errorf(
+				"deviation %q is target-scoped; clearing target deviations via cleardeviation is not supported",
+				name)
+		case DeviationType_CONFIG:
+			if cfg, ok := configsByName[resource]; ok {
+				return cfg, nil
+			}
+			return nil, fmt.Errorf(
+				"config %q (from deviation name %q) not found for target %s",
+				resource, name, targetKey.Name)
+		}
+	}
+	return nil, fmt.Errorf("config %q not found for target %s", name, targetKey.Name)
+}
+
+// validationErrorsToFieldErrors converts per-entry validation results into
+// the field.ErrorList shape that apierrors.NewInvalid expects.
+func validationErrorsToFieldErrors(results []TargetClearDeviationConfigResult) field.ErrorList {
+	errs := make(field.ErrorList, 0, len(results))
+	for i, r := range results {
+		msg := strings.Join(r.Errors, "; ")
+		if msg == "" {
+			msg = "validation failed"
+		}
+		errs = append(errs, field.Invalid(
+			field.NewPath("spec", "config").Index(i).Child("name"),
+			r.Name,
+			msg,
+		))
+	}
+	return errs
 }
 
 func GetGVKNSN(obj client.Object) string {
@@ -420,7 +466,6 @@ func buildClearDeviationStatus(
 
 	status.Warnings = rsp.Warnings
 
-	// Map intent names (GVKNSN) back to config names for the response
 	intentToName := make(map[string]string, len(configsByName))
 	for name, cfg := range configsByName {
 		intentToName[GetGVKNSN(cfg)] = name
@@ -440,14 +485,16 @@ func buildClearDeviationStatus(
 		})
 	}
 
-	// Configs not in response succeeded silently
+	// Inherit the overall transaction outcome for any config the
+	// data-server didn't explicitly report on.
 	for _, cfg := range clearConfigs {
-		if !responded[cfg.Name] {
-			status.Results = append(status.Results, TargetClearDeviationConfigResult{
-				Name:    cfg.Name,
-				Success: err == nil,
-			})
+		if responded[cfg.Name] {
+			continue
 		}
+		status.Results = append(status.Results, TargetClearDeviationConfigResult{
+			Name:    cfg.Name,
+			Success: err == nil,
+		})
 	}
 
 	return status

--- a/apis/config/v1alpha1/deviation_helpers.go
+++ b/apis/config/v1alpha1/deviation_helpers.go
@@ -90,7 +90,13 @@ func (r *Deviation) GetTargetNamespaceName() (*types.NamespacedName, error) {
 	}, nil
 }
 
-// DeviationName returns the canonical name for a Deviation CR.
+// DeviationName is the v1alpha1 alias for config.DeviationName.
 func DeviationName(typ DeviationType, resourceName string) string {
-	return fmt.Sprintf("%s-%s", typ, resourceName)
+	return config.DeviationName(config.DeviationType(typ), resourceName)
+}
+
+// ParseDeviationName is the v1alpha1 alias for config.ParseDeviationName.
+func ParseDeviationName(name string) (DeviationType, string, bool) {
+	typ, resource, ok := config.ParseDeviationName(name)
+	return DeviationType(typ), resource, ok
 }


### PR DESCRIPTION
`cleardeviation` could return 200 OK with errors hidden in the response body, which `kubectl sdc deviation --revert` (and any other status-code-only client) interpreted as success — so deviations stayed un-cleared with no feedback.
It also only accepted the Config CR name, even though clients usually have the Deviation CR name (`config-<configName>`) obtained through `kubectl get deviations`. These used to be equal but was a bug fixed in #437

## Changes
- Reject the whole batch with HTTP 422 if any entry fails pre-flight validation (unknown config, invalid path, revertive config, target-scoped deviation name). Per-entry errors are still in the body so the caller can fix everything in one go. Transaction-execution outcomes on the device continue to return 200 with per-entry `Status.Results`.
- Accept either the Config CR name or the Deviation CR name in `TargetClearDeviationConfig.Name`. Target-scoped deviation names are rejected with a clear error until we have a proper code path for them.
- Move the `<type>-<resourceName>` naming convention into one helper (`config.DeviationName` / `ParseDeviationName`); `v1alpha1` delegates.

## Notes
- Valid requests behave the same. The only callers that see a new HTTP error are ones that previously got 200 OK with errors silently hidden.
- TBD: How to deal with 'clearing' target deviations