### PR TITLE
Fix panic when resolving secrets on first reconcile

### DIFF
--- a/pkg/reconcilers/configresolver/reconciler.go
+++ b/pkg/reconcilers/configresolver/reconciler.go
@@ -304,7 +304,7 @@ func (r *reconciler) detectChange(
 ) (changeResult, map[string]*corev1.Secret, error) {
 	if !hasExisting {
 		// First time or externally deleted — full resolution required.
-		return changeResult{configChanged: true}, nil, nil
+		return changeResult{configChanged: true}, make(map[string]*corev1.Secret), nil
 	}
 
 	result := changeResult{}
@@ -443,6 +443,9 @@ func (r *reconciler) buildLeafResolver(
 	cfg *configv1alpha1.Config,
 	fetched map[string]*corev1.Secret,
 ) (*leafResolver, map[string]string, []string, error) {
+	if fetched == nil {
+		fetched = make(map[string]*corev1.Secret)
+	}
 	lr := &leafResolver{
 		values:     map[string]string{},
 		unresolved: map[string]error{},

--- a/pkg/reconcilers/configresolver/resolver_test.go
+++ b/pkg/reconcilers/configresolver/resolver_test.go
@@ -434,6 +434,19 @@ func newTestReconciler(t *testing.T, kr *keyring.KeyRing, objs ...client.Object)
 func Test_buildLeafResolver(t *testing.T) {
 	ctx := context.Background()
 
+	t.Run("nil fetched map is initialized", func(t *testing.T) {
+		r := newTestReconciler(t, nil, mkSecret("mysecret", map[string]string{"key0": "val0"}))
+		cfg := mkConfig([]configv1alpha1.ConfigVar{mkVar("pw", "mysecret", "key0")})
+
+		lr, _, _, err := r.buildLeafResolver(ctx, cfg, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if lr.values["pw"] != "val0" {
+			t.Errorf("values[pw] = %q, want val0", lr.values["pw"])
+		}
+	})
+
 	t.Run("resolved var: value, hash and secret name recorded", func(t *testing.T) {
 		r := newTestReconciler(t, nil, mkSecret("mysecret", map[string]string{"key0": "val0"}))
 		cfg := mkConfig([]configv1alpha1.ConfigVar{mkVar("pw", "mysecret", "key0")})


### PR DESCRIPTION
## Summary
- Initialize the pre-fetched secret map in `detectChange` when no `SensitiveConfig` exists yet, instead of returning `nil`
- Add a defensive nil-map guard in `buildLeafResolver` so callers cannot trigger a panic on map assignment
- Add a regression test covering the nil `fetched` map path

## Context
On first reconcile (`configChanged: true`, no existing `SensitiveConfig`), the resolver passed a nil `fetched` map into `buildLeafResolver`, which panicked with `assignment to entry in nil map` when caching a fetched secret.

## Test plan
- [x] `go test ./pkg/reconcilers/configresolver/... -run Test_buildLeafResolver`
- [ ] Apply a Config with `vars.secretRef` on a fresh cluster (no existing `SensitiveConfig`) and confirm the resolver reconciles without panic


Made with [Cursor](https://cursor.com)