### PR TITLE
fix: include resolverOK in ready gate in SetOverallStatus

### DIFF
--- a/apis/config/v1alpha1/config_helpers.go
+++ b/apis/config/v1alpha1/config_helpers.go
@@ -222,7 +222,7 @@ func (r *Config) SetOverallStatus() {
 	// An absent resolver condition (no secrets, or resolver hasn't run yet) is not a failure.
 	resolverOK := resolverC.Status == "" || resolverC.IsTrue()
 
-	ready := cfgC.IsTrue() && tgtC.IsTrue()
+	ready := cfgC.IsTrue() && tgtC.IsTrue() && resolverOK
 
 	if ready {
 		// important: only set overall Ready type, do not drop other conditions


### PR DESCRIPTION
## Summary

- `resolverOK` was computed in `SetOverallStatus` but never included in the `ready` expression
- If `ConfigReady` and `TargetReady` were both `True`, an explicit `Resolver=False` condition (e.g. referenced Secret deleted/rotated) was silently masked — the resource reported `Ready=True` with a potentially stale or incorrect live config
- Fix: add `&& resolverOK` to the `ready` conjunction so a failed secret resolver correctly blocks the overall Ready condition

## Root cause

```go
// before
ready := cfgC.IsTrue() && tgtC.IsTrue()

// after
ready := cfgC.IsTrue() && tgtC.IsTrue() && resolverOK
```

The `!resolverOK` branch in the downstream `switch` was dead code in the previously-healthy scenario because the function returned early before reaching it.

## Test plan
- [ ] Verify that setting `Resolver` condition to `False` on a Config whose `ConfigReady` and `TargetReady` are `True` now results in `Ready=False`
- [ ] Verify that an absent `Resolver` condition (empty status) still allows `Ready=True` when the other two conditions are met

Made with [Cursor](https://cursor.com)