### PR TITLE
fix: correct protobuf wire type for ConfigHash and SecretKeyHashes

### DIFF
--- a/apis/config/sensitive_config_types.go
+++ b/apis/config/sensitive_config_types.go
@@ -35,10 +35,10 @@ type SensitiveConfigSpec struct {
 	// Revertive defines if this CR is enabled for revertive or non revertve operation
 	Revertive *bool `json:"revertive,omitempty" protobuf:"varint,4,opt,name=revertive"`
 	// ConfigHash is SHA-256 of the original (unresolved) cfg.Spec.Config blobs.
-	ConfigHash string `json:"configHash,omitempty" protobuf:"varint,5,opt,name=configHash"`
+	ConfigHash string `json:"configHash,omitempty" protobuf:"bytes,5,opt,name=configHash"`
 	// SecretKeyHashes maps "secretName/keyName" → sha256(secret.Data[keyName]).
 	// Tracks only the specific key value — not the whole Secret object.
-	SecretKeyHashes map[string]string `json:"secretKeyHashes,omitempty" protobuf:"varint,6,opt,name=secretKeyHashes"`
+	SecretKeyHashes map[string]string `json:"secretKeyHashes,omitempty" protobuf:"bytes,6,opt,name=secretKeyHashes"`
 	// Payload contains the encrypted resolved []ConfigBlob.
 	// Plaintext is JSON-marshaled []ConfigBlob with all secret::name::key refs substituted.
 	Payload EncryptedPayload `json:"payload" protobuf:"bytes,7,opt,name=payload"`


### PR DESCRIPTION
## Summary

- `ConfigHash` (`string`) and `SecretKeyHashes` (`map[string]string`) in `SensitiveConfigSpec` were tagged with protobuf wire type `varint`
- `varint` is only valid for integer scalars; `string` and `map` fields require wire type `bytes`
- Any protobuf serialisation/deserialisation path (e.g. etcd storage in an aggregated API server) would produce garbled data or a runtime decode error
- Fix: change both field tags from `varint` to `bytes`

## Root cause

```go
// before
ConfigHash      string            `... protobuf:"varint,5,opt,name=configHash"`
SecretKeyHashes map[string]string `... protobuf:"varint,6,opt,name=secretKeyHashes"`

// after
ConfigHash      string            `... protobuf:"bytes,5,opt,name=configHash"`
SecretKeyHashes map[string]string `... protobuf:"bytes,6,opt,name=secretKeyHashes"`
```

The other fields in the struct (`Lifecycle`, `Payload`, etc.) already use `bytes` correctly; these two were a copy-paste mistake from integer fields above them.

## Test plan
- [ ] Verify round-trip protobuf encode/decode of a `SensitiveConfig` with non-empty `ConfigHash` and `SecretKeyHashes` produces identical values
- [ ] Confirm no existing etcd-stored objects are corrupted (field was newly introduced on the `sensitive` branch, so no migration needed)

Made with [Cursor](https://cursor.com)