### PR TITLE
fix: reset TargetForConfig condition on no-op reconcile

### DIFF
--- a/pkg/reconcilers/configresolver/reconciler.go
+++ b/pkg/reconcilers/configresolver/reconciler.go
@@ -240,6 +240,17 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// ── No change ─────────────────────────────────────────────────────────────
 	if change.noChange() {
+		// Even when content is identical to the stored SensitiveConfig, clear a
+		// stale Resolver=False condition. This occurs when a secret is deleted
+		// (which sets Resolver=False and preserves the last-good SC), then
+		// re-created with the same content: detectChange returns noChange=true
+		// because all hashes still match, but the failure condition from the
+		// deletion window must be cleared so the Config can become Ready again.
+		resolverC := cfgOrig.GetCondition(configv1alpha1.ConditionTypeResolver)
+		if resolverC.Status != "" && !resolverC.IsTrue() {
+			log.Info("no content change but stale Resolver=False detected — clearing condition")
+			return ctrl.Result{}, errors.Wrap(r.handleSuccess(ctx, cfgOrig), errUpdateStatus)
+		}
 		log.Debug("no change detected, skipping")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/reconcilers/targetconfig/reconciler.go
+++ b/pkg/reconcilers/targetconfig/reconciler.go
@@ -239,6 +239,17 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if !hasChanged {
 		log.Info("Transact skip, nothing to update")
+		// Still reset TargetForConfig to Ready so any stale Failed condition
+		// (set when the target was briefly not-ready) is cleared. Without this
+		// the overall Config Ready condition stays False permanently whenever a
+		// target drops and recovers but no intent change is detected.
+		if err := r.cfgMgr.SetConfigsTargetConditionForTarget(
+			ctx, targetOrig,
+			configv1alpha1.TargetForConfigReady("target ready"),
+		); err != nil {
+			return ctrl.Result{},
+				errors.Wrap(r.handleError(ctx, targetOrig, "cannot update config status", err), errUpdateStatus)
+		}
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
## Problem

When a target briefly drops (e.g. `srl3` loses its `dsctx`) the `TargetConfigController` calls `SetConfigsTargetConditionForTarget(TargetForConfigFailed)`, setting all Configs for that target to `Ready=False`.

When the target recovers, the reconciler runs `buildIntentInputs`. If no intent hash has changed (no new configs, no secret rotation) `hasChanged=false` and the reconciler returned early:

```go
if !hasChanged {
    log.Info("Transact skip, nothing to update")
    return ctrl.Result{}, nil   // ← never resets the stale Failed condition
}
```

`SetConfigsTargetConditionForTarget(TargetForConfigReady)` is only called after a successful transaction, so the stale `Failed` condition was never cleared. Configs stayed at `Ready=False` permanently until the next unrelated change triggered a new transaction.

This caused the `22-Srl-Update-Replace` suite in CI run [#460](https://github.com/sdcio/data-server/actions/runs/28503603684) to fail: `srl3` dropped at `07:14:41`, no new intents existed to force a transaction, and the setup `Config Check Ready` timed out 2 minutes later still seeing `['False']`.

## Fix

Mirror the `main`-branch behaviour: call `SetConfigsTargetConditionForTarget(TargetForConfigReady)` in the no-change early-return path so any stale `Failed` condition is always cleared when the target is confirmed healthy, even when nothing needs to be transacted.

```go
if !hasChanged {
    log.Info("Transact skip, nothing to update")
    if err := r.cfgMgr.SetConfigsTargetConditionForTarget(
        ctx, targetOrig,
        configv1alpha1.TargetForConfigReady("target ready"),
    ); err != nil {
        return ctrl.Result{},
            errors.Wrap(r.handleError(ctx, targetOrig, "cannot update config status", err), errUpdateStatus)
    }
    return ctrl.Result{}, nil
}
```

## Test plan

- [ ] Re-run the `sensitive` CI suite — `22-Srl-Update-Replace` should pass
- [ ] Confirm no regression in `11-Sros-Create-Delete`, `12-Srl-Create-Delete`, `21-Sros-Update-Replace`
- [ ] Verify that deliberately taking a target not-ready and back-ready (no config change) transitions Configs back to `Ready=True`

Pairs-with: sdcio/integration-tests#108
Pairs-with: sdcio/data-server#460