### PR TITLE
Add missing storage version

### DIFF
--- a/apis/config/target_cleardeviation_types.go
+++ b/apis/config/target_cleardeviation_types.go
@@ -61,6 +61,7 @@ type TargetClearDeviationConfigResult struct {
 
 // TargetClearDeviation is the Schema for the TargetClearDeviation API
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 type TargetClearDeviation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/apis/config/target_configblame_types.go
+++ b/apis/config/target_configblame_types.go
@@ -25,6 +25,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 
 // TargetConfigBlame is the Schema for the TargetConfigBlame API
 type TargetConfigBlame struct {

--- a/apis/config/target_runningconfig_types.go
+++ b/apis/config/target_runningconfig_types.go
@@ -24,6 +24,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 
 // TargetRunningConfig is the Schema for the TargetRunning API
 type TargetRunningConfig struct {

--- a/apis/config/v1alpha1/target_cleardeviation_types.go
+++ b/apis/config/v1alpha1/target_cleardeviation_types.go
@@ -61,6 +61,7 @@ type TargetClearDeviationConfigResult struct {
 
 // TargetClearDeviation is the Schema for the TargetClearDeviation API
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 type TargetClearDeviation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/apis/config/v1alpha1/target_configblame_types.go
+++ b/apis/config/v1alpha1/target_configblame_types.go
@@ -25,6 +25,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 
 // TargetConfigBlame is the Schema for the TargetConfigBlame API
 type TargetConfigBlame struct {

--- a/apis/config/v1alpha1/target_runningconfig_types.go
+++ b/apis/config/v1alpha1/target_runningconfig_types.go
@@ -24,6 +24,7 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:storageversion
 
 // TargetRunningConfig is the Schema for the TargetRunningConfig API
 type TargetRunningConfig struct {

--- a/crds/config.sdcio.dev_configs.yaml
+++ b/crds/config.sdcio.dev_configs.yaml
@@ -72,7 +72,7 @@ spec:
                 type: object
               priority:
                 description: Priority defines the priority of this config
-                format: int64
+                format: int32
                 type: integer
               revertive:
                 description: Revertive defines if this CR is enabled for revertive
@@ -118,7 +118,7 @@ spec:
                     type: object
                   priority:
                     description: Priority defines the priority of this config
-                    format: int64
+                    format: int32
                     type: integer
                   revertive:
                     description: Revertive defines if this CR is enabled for revertive
@@ -270,7 +270,7 @@ spec:
                 type: object
               priority:
                 description: Priority defines the priority of this config
-                format: int64
+                format: int32
                 type: integer
               revertive:
                 description: Revertive defines if this CR is enabled for revertive
@@ -321,7 +321,7 @@ spec:
                     type: object
                   priority:
                     description: Priority defines the priority of this config
-                    format: int64
+                    format: int32
                     type: integer
                   revertive:
                     description: Revertive defines if this CR is enabled for revertive

--- a/crds/config.sdcio.dev_configsets.yaml
+++ b/crds/config.sdcio.dev_configsets.yaml
@@ -72,7 +72,7 @@ spec:
                 type: object
               priority:
                 description: Priority defines the priority of this config
-                format: int64
+                format: int32
                 type: integer
               revertive:
                 description: Revertive defines if this CR is enabled for revertive
@@ -320,7 +320,7 @@ spec:
                 type: object
               priority:
                 description: Priority defines the priority of this config
-                format: int64
+                format: int32
                 type: integer
               revertive:
                 description: Revertive defines if this CR is enabled for revertive

--- a/crds/config.sdcio.dev_targetcleardeviations.yaml
+++ b/crds/config.sdcio.dev_targetcleardeviations.yaml
@@ -40,23 +40,160 @@ spec:
           spec:
             description: TargetClearDeviationSpec defines the desired state of Target
             properties:
-              paths:
-                description: Paths provide the path of the deviation to be cleared
+              config:
+                description: Config defines the clear deviations configs to applied
+                  on the taget
                 items:
-                  type: string
+                  properties:
+                    name:
+                      description: Name of the config on which the paths should be
+                        cleared
+                      type: string
+                    paths:
+                      description: Paths provide the path of the deviation to be cleared
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - paths
+                  type: object
                 type: array
             required:
-            - paths
+            - config
             type: object
           status:
             properties:
-              cleared:
-                type: integer
               message:
+                description: Message is a global message for the transaction
                 type: string
+              results:
+                description: Results holds per-config outcomes, keyed by intent name
+                items:
+                  properties:
+                    errors:
+                      description: Errors lists any errors for this specific config
+                      items:
+                        type: string
+                      type: array
+                    message:
+                      description: Message provides detail on the outcome
+                      type: string
+                    name:
+                      description: Name of the config on which the paths should be
+                        cleared
+                      type: string
+                    success:
+                      description: Success indicates whether the clear deviation was
+                        successful
+                      type: boolean
+                    warnings:
+                      description: Warnings lists any warnings for this specific config
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - success
+                  type: object
+                type: array
+              warnings:
+                description: Warnings are global warnings from the transaction
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetClearDeviation is the Schema for the TargetClearDeviation
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetClearDeviationSpec defines the desired state of Target
+            properties:
+              config:
+                description: Config defines the clear deviations configs to applied
+                  on the taget
+                items:
+                  properties:
+                    name:
+                      description: Name of the config on which the paths should be
+                        cleared
+                      type: string
+                    paths:
+                      description: Paths provide the path of the deviation to be cleared
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - paths
+                  type: object
+                type: array
             required:
-            - cleared
-            - message
+            - config
+            type: object
+          status:
+            properties:
+              message:
+                description: Message is a global message for the transaction
+                type: string
+              results:
+                description: Results holds per-config outcomes, keyed by intent name
+                items:
+                  properties:
+                    errors:
+                      description: Errors lists any errors for this specific config
+                      items:
+                        type: string
+                      type: array
+                    message:
+                      description: Message provides detail on the outcome
+                      type: string
+                    name:
+                      description: Name of the config on which the paths should be
+                        cleared
+                      type: string
+                    success:
+                      description: Success indicates whether the clear deviation was
+                        successful
+                      type: boolean
+                    warnings:
+                      description: Warnings lists any warnings for this specific config
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - success
+                  type: object
+                type: array
+              warnings:
+                description: Warnings are global warnings from the transaction
+                items:
+                  type: string
+                type: array
             type: object
         type: object
     served: true

--- a/crds/config.sdcio.dev_targetconfigblames.yaml
+++ b/crds/config.sdcio.dev_targetconfigblames.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: targetconfigblames.config.sdcio.dev
+spec:
+  group: config.sdcio.dev
+  names:
+    kind: TargetConfigBlame
+    listKind: TargetConfigBlameList
+    plural: targetconfigblames
+    singular: targetconfigblame
+  scope: Namespaced
+  versions:
+  - name: config
+    schema:
+      openAPIV3Schema:
+        description: TargetConfigBlame is the Schema for the TargetConfigBlame API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - value
+        type: object
+    served: true
+    storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetConfigBlame is the Schema for the TargetConfigBlame API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - value
+        type: object
+    served: true
+    storage: true

--- a/crds/config.sdcio.dev_targetrunningconfigs.yaml
+++ b/crds/config.sdcio.dev_targetrunningconfigs.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: targetrunningconfigs.config.sdcio.dev
+spec:
+  group: config.sdcio.dev
+  names:
+    kind: TargetRunningConfig
+    listKind: TargetRunningConfigList
+    plural: targetrunningconfigs
+    singular: targetrunningconfig
+  scope: Namespaced
+  versions:
+  - name: config
+    schema:
+      openAPIV3Schema:
+        description: TargetRunningConfig is the Schema for the TargetRunning API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          format:
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            type: string
+        required:
+        - format
+        - value
+        type: object
+    served: true
+    storage: true
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetRunningConfig is the Schema for the TargetRunningConfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            type: string
+        required:
+        - value
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Since commit e4f94d14135bd83986cf5bcd408a6d0582e96ab9 the `make manifests` command fails with these errors:

```
test -s /home/user/src/github.com/sdcio/config-server/bin/controller-gen || GOBIN=/home/user/src/github.com/sdcio/config-server/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.0
mkdir -p crds
/home/user/src/github.com/sdcio/config-server/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./apis/..." output:crd:artifacts:config=crds
github.com/sdcio/config-server/apis/config:-: CRD for TargetClearDeviation.config.sdcio.dev has no storage version
github.com/sdcio/config-server/apis/config:-: CRD for TargetRunningConfig.config.sdcio.dev has no storage version
github.com/sdcio/config-server/apis/config/v1alpha1:-: CRD for TargetConfigBlame.config.sdcio.dev has no storage version
Error: not all generators ran successfully
run `controller-gen rbac:roleName=manager-role crd webhook paths=./apis/... output:crd:artifacts:config=crds -w` to see all available markers, or `controller-gen rbac:roleName=manager-role crd webhook paths=./apis/... output:crd:artifacts:config=crds -h` for usage
make: *** [crds] Error 1
```

This adds the missing storage version to fix manifests generation and includes a fresh version of the manifests.
