### PR TITLE
retry config transactions on Unavailable errors

### DIFF
--- a/pkg/reconcilers/targetconfig/reconciler.go
+++ b/pkg/reconcilers/targetconfig/reconciler.go
@@ -36,8 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -91,6 +93,13 @@ func (r *reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, c i
 
 	return nil, ctrl.NewControllerManagedBy(mgr).
 		Named(reconcilerName).
+		WithOptions(controller.Options{
+			// Recoverable failures are returned as errors;
+			// Use custom rate limiter to cap the backoff max to 60s
+			// instead of the default ~1000s cap.
+			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](
+				1*time.Second, 60*time.Second),
+		}).
 		For(&configv1alpha1.Target{}).
 		Watches(&configv1alpha1.Config{}, &eventhandler.ConfigForTargetEventHandler{Client: mgr.GetClient(), ControllerName: reconcilerName}).
 		Complete(r)
@@ -209,18 +218,15 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err != nil {
 		log.Warn("config transaction failed", "retry", retry, "err", err)
 		if retry {
-			if err := r.transactor.SetConfigsTargetConditionForTarget(
+			if serr := r.transactor.SetConfigsTargetConditionForTarget(
 				ctx,
 				targetOrig,
 				configv1alpha1.TargetForConfigReady("target ready"),
-			); err != nil {
-				return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, "", err), errUpdateStatus)
+			); serr != nil {
+				return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, "", serr), errUpdateStatus)
 			}
-			return ctrl.Result{
-					RequeueAfter: 500 * time.Millisecond,
-					Requeue:      true,
-				},
-				errors.Wrap(r.handleError(ctx, targetOrig, "", err), errUpdateStatus)
+			// Recoverable failure: trigger backoff
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, errors.Wrap(r.handleError(ctx, targetOrig, "", err), errUpdateStatus)
 	}

--- a/pkg/sdc/target/manager/runtime_test.go
+++ b/pkg/sdc/target/manager/runtime_test.go
@@ -55,6 +55,27 @@ func TestProcessTransactionResponse(t *testing.T) {
 			expectErr:   true,
 			recoverable: false,
 		},
+		"Recoverable Unavailable (not connected)": {
+			rsp:         nil,
+			err:         status.Error(codes.Unavailable, "test.test is not connected"),
+			expected:    "error: rpc error: code = Unavailable desc = test.test is not connected",
+			expectErr:   true,
+			recoverable: true,
+		},
+		"Recoverable DeadlineExceeded": {
+			rsp:         nil,
+			err:         status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expected:    "error: rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+			expectErr:   true,
+			recoverable: true,
+		},
+		"Non-Recoverable Unknown not connected (pre-fix data-server)": {
+			rsp:         nil,
+			err:         status.Error(codes.Unknown, "test.test is not connected"),
+			expected:    "error: rpc error: code = Unknown desc = test.test is not connected",
+			expectErr:   true,
+			recoverable: false,
+		},
 		"Intent Errors in Response": {
 			rsp: &sdcpb.TransactionSetResponse{
 				Intents: map[string]*sdcpb.TransactionSetResponseIntent{
@@ -116,6 +137,30 @@ func TestProcessTransactionResponse(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expected, warning)
 			}
+		})
+	}
+}
+
+func TestIsRecoverableTransactionError(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":                      {err: nil, want: false},
+		"aborted (lock)":           {err: status.Error(codes.Aborted, "datastore is locked"), want: true},
+		"resource exhausted":       {err: status.Error(codes.ResourceExhausted, "backpressure"), want: true},
+		"unavailable not connected": {err: status.Error(codes.Unavailable, "test.test is not connected"), want: true},
+		"unavailable not ready":    {err: status.Error(codes.Unavailable, "not ready"), want: true},
+		"deadline exceeded":        {err: status.Error(codes.DeadlineExceeded, "timeout"), want: true},
+		"unknown (pre-fix)":        {err: status.Error(codes.Unknown, "test.test is not connected"), want: false},
+		"invalid argument":         {err: status.Error(codes.InvalidArgument, "bad"), want: false},
+		"not found":                {err: status.Error(codes.NotFound, "missing"), want: false},
+		"plain error":              {err: errors.New("boom"), want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRecoverableTransactionError(tc.err))
 		})
 	}
 }

--- a/pkg/sdc/target/manager/transactor.go
+++ b/pkg/sdc/target/manager/transactor.go
@@ -33,8 +33,6 @@ import (
 	configv1alpha1apply "github.com/sdcio/config-server/pkg/generated/applyconfiguration/config/v1alpha1"
 	"github.com/sdcio/config-server/pkg/reconcilers/resource"
 	sdcpb "github.com/sdcio/sdc-protos/sdcpb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/prototext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -767,15 +765,7 @@ func analyzeIntentResponse(err error, rsp *sdcpb.TransactionSetResponse) Transac
 
 	if err != nil {
 		result.GlobalError = fmt.Errorf("transaction error: %w", err)
-		// gRPC status code to determine recoverability
-		if statusErr, ok := status.FromError(err); ok {
-			switch statusErr.Code() {
-			case codes.Aborted, codes.ResourceExhausted:
-				result.Recoverable = true
-			default:
-				result.Recoverable = false
-			}
-		}
+		result.Recoverable = isRecoverableTransactionError(err)
 	}
 
 	if rsp != nil {

--- a/pkg/sdc/target/manager/utils.go
+++ b/pkg/sdc/target/manager/utils.go
@@ -38,15 +38,7 @@ func processTransactionResponse(ctx context.Context, rsp *sdcpb.TransactionSetRe
 	var recoverable bool
 	if rsperr != nil {
 		errs = errors.Join(errs, fmt.Errorf("error: %s", rsperr.Error()))
-		if er, ok := status.FromError(rsperr); ok {
-			switch er.Code() {
-			// Aborted is the refering to a lock in the dataserver
-			case codes.Aborted, codes.ResourceExhausted:
-				recoverable = true
-			default:
-				recoverable = false
-			}
-		}
+		recoverable = isRecoverableTransactionError(rsperr)
 	}
 	if rsp != nil {
 		for _, warning := range rsp.Warnings {
@@ -71,4 +63,22 @@ func processTransactionResponse(ctx context.Context, rsp *sdcpb.TransactionSetRe
 	}
 	log.Debug("transaction response", "rsp", prototext.Format(rsp), "msg", msg, "error", err)
 	return msg, err
+}
+
+// isRecoverableTransactionError reports whether a data-server transaction error
+// is transient and worth retrying, based on its gRPC status code.
+func isRecoverableTransactionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Aborted, codes.ResourceExhausted, codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
# Problem
A data-server "not connected" error (device unreachable) was classified as
non-recoverable, so the Config was marked `FailedUnRecoverable` and never
retried resulting in a config applied while the device was down being stuck in failed state,
even after the device recovered.

## Change
- Classify recoverability by gRPC code via `isRecoverableTransactionError`
- targetconfig reconciler: use exponential backoff, bounded to 1s–60s, replacing the fixed 500ms retry

Pairs-with: sdcio/data-server#466