### PR TITLE
fix(ci): prevent grep no-match from aborting resolve-paired-refs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
           # Extract the PR number from a "Pairs-with: org/repo#NNN" line
           pairs_with_pr() {
             local repo="$1"
-            printf '%s' "$BODY" | grep -oP "(?i)Pairs-with:\s+${repo}#\K[0-9]+" | head -1
+            printf '%s' "$BODY" | grep -oP "(?i)Pairs-with:\s+${repo}#\K[0-9]+" | head -1 || true
           }
 
           # Resolve data-server: PR# → branch → short SHA (used as GHCR image tag)


### PR DESCRIPTION
## Summary

Same bug as sdcio/data-server#467.

With `set -euo pipefail` active, `grep` exits with code 1 when no `Pairs-with:` lines are present in the PR body (e.g. Dependabot bumps). This kills the `resolve-paired-refs` script before it can write the `main` fallback to `GITHUB_OUTPUT`.

**One-line fix:** add `|| true` inside `pairs_with_pr()` so a no-match is treated as returning an empty string, not a failure.

## Test plan

- [ ] Dependabot / any PR without `Pairs-with:` lines → `resolve-paired-refs` passes, outputs default to `main`
- [ ] PR with `Pairs-with: sdcio/data-server#NNN` → resolves correctly as before

Made with [Cursor](https://cursor.com)