### PR TITLE
Bump golangci-lint to v2.12.2 for go1.26 compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.12.2

--- a/pkg/output/prometheusserver/prommetric.go
+++ b/pkg/output/prometheusserver/prommetric.go
@@ -116,7 +116,7 @@ func (p *PromMetric) String() string {
 		}
 		sb.WriteString("],")
 	}
-	sb.WriteString(fmt.Sprintf("value=%f,", p.value))
+	fmt.Fprintf(&sb, "value=%f,", p.value)
 	sb.WriteString("time=")
 	if p.Time != nil {
 		sb.WriteString(p.Time.String())

--- a/pkg/reconcilers/configset/reconciler.go
+++ b/pkg/reconcilers/configset/reconciler.go
@@ -408,7 +408,7 @@ func (r *reconciler) determineOverallStatus(_ context.Context, configSet *config
 	var sb strings.Builder
 	for _, targetStatus := range configSet.Status.Targets {
 		if targetStatus.Status == metav1.ConditionFalse {
-			sb.WriteString(fmt.Sprintf("target %s config not ready, msg %s;", targetStatus.Name, targetStatus.Message))
+			fmt.Fprintf(&sb, "target %s config not ready, msg %s;", targetStatus.Name, targetStatus.Message)
 		}
 	}
 	return sb.String()


### PR DESCRIPTION
## Summary
- The lint workflow pins `golangci-lint` to `v2.4`, which is built with go1.25. Once `go.mod` targets `go1.26` (as in #474), the lint job fails with `can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.0)`.
- Bump to `v2.12.2`, the latest release, which added go1.26 support.
- Fix two new `staticcheck` `QF1012` findings (`WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(...)`) surfaced by the newer linter.

## Test plan
- [x] `go build ./...` succeeds
- [x] `golangci-lint run ./...` (v2.12.2) reports 0 issues

Made with [Cursor](https://cursor.com)