### PR TITLE
fix(cleardeviation): retry TransactionSet on transient Aborted errors

### DIFF
--- a/apis/config/target_cleardeviation_test.go
+++ b/apis/config/target_cleardeviation_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package config
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sdcio/sdc-protos/sdcpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -58,4 +64,105 @@ func TestResolveClearDeviationConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsRecoverableClearDeviationTxError(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":                 {nil, false},
+		"aborted":             {status.Error(codes.Aborted, "transaction ongoing"), true},
+		"resource exhausted":  {status.Error(codes.ResourceExhausted, "backpressure"), true},
+		"unavailable":         {status.Error(codes.Unavailable, "not connected"), true},
+		"deadline exceeded":   {status.Error(codes.DeadlineExceeded, "timeout"), true},
+		"failed precondition": {status.Error(codes.FailedPrecondition, "invalid"), false},
+		"plain error":         {errors.New("boom"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isRecoverableClearDeviationTxError(tc.err); got != tc.want {
+				t.Errorf("isRecoverableClearDeviationTxError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryClearDeviationTx(t *testing.T) {
+	t.Run("succeeds without retry", func(t *testing.T) {
+		calls := 0
+		rsp, err := retryClearDeviationTx(context.Background(), 4, time.Millisecond, func() (*sdcpb.TransactionSetResponse, error) {
+			calls++
+			return &sdcpb.TransactionSetResponse{}, nil
+		})
+		if err != nil || rsp == nil {
+			t.Fatalf("got rsp=%v err=%v, want success", rsp, err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (no retry needed)", calls)
+		}
+	})
+
+	t.Run("retries recoverable error then succeeds", func(t *testing.T) {
+		calls := 0
+		rsp, err := retryClearDeviationTx(context.Background(), 4, time.Millisecond, func() (*sdcpb.TransactionSetResponse, error) {
+			calls++
+			if calls < 3 {
+				return nil, status.Error(codes.Aborted, "transaction ongoing")
+			}
+			return &sdcpb.TransactionSetResponse{}, nil
+		})
+		if err != nil || rsp == nil {
+			t.Fatalf("got rsp=%v err=%v, want eventual success", rsp, err)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("stops immediately on non-recoverable error", func(t *testing.T) {
+		calls := 0
+		_, err := retryClearDeviationTx(context.Background(), 4, time.Millisecond, func() (*sdcpb.TransactionSetResponse, error) {
+			calls++
+			return nil, status.Error(codes.FailedPrecondition, "invalid")
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (should not retry non-recoverable error)", calls)
+		}
+	})
+
+	t.Run("gives up after maxAttempts on persistent recoverable error", func(t *testing.T) {
+		calls := 0
+		_, err := retryClearDeviationTx(context.Background(), 3, time.Millisecond, func() (*sdcpb.TransactionSetResponse, error) {
+			calls++
+			return nil, status.Error(codes.Aborted, "transaction ongoing")
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3 (maxAttempts)", calls)
+		}
+	})
+
+	t.Run("aborts retries when context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		_, err := retryClearDeviationTx(ctx, 5, 50*time.Millisecond, func() (*sdcpb.TransactionSetResponse, error) {
+			calls++
+			if calls == 1 {
+				cancel()
+			}
+			return nil, status.Error(codes.Aborted, "transaction ongoing")
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (should stop after context cancellation)", calls)
+		}
+	})
 }

--- a/apis/config/target_helpers.go
+++ b/apis/config/target_helpers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/henderiw/apiserver-store/pkg/storebackend"
@@ -27,6 +28,8 @@ import (
 	"github.com/sdcio/config-server/apis/condition"
 	dsclient "github.com/sdcio/config-server/pkg/sdc/dataserver/client"
 	"github.com/sdcio/sdc-protos/sdcpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -403,9 +406,70 @@ func GetGVKNSN(obj client.Object) string {
 	return fmt.Sprintf("%s.%s", obj.GetNamespace(), obj.GetName())
 }
 
+// clearDeviationTxMaxAttempts and clearDeviationTxBaseBackoff bound the retry
+// below: this handler runs synchronously inside a REST request (the CLI/user
+// is waiting on it), so retries must stay short — unlike the targetconfig
+// reconciler's background, requeue-based backoff (capped at 60s), a
+// foreground call can only afford a few hundred milliseconds per attempt.
+const (
+	clearDeviationTxMaxAttempts = 4
+	clearDeviationTxBaseBackoff = 200 * time.Millisecond
+)
+
 // executeClearDeviationTx opens a connection to the dataserver,
 // sends the TransactionSetRequest, and confirms on success.
+//
+// TransactionSet fails with a codes.Aborted "transaction ongoing" error
+// whenever another transaction is already registered (but not yet
+// Confirmed/Cancelled) on the same datastore — e.g. the targetconfig
+// reconciler reconciling a different Config/ConfigSet against the same
+// target. That window is normally only open for as long as the other
+// transaction takes to Confirm, so a short, bounded retry here resolves the
+// common case without requiring the caller (kubectl-sdc) to retry itself.
 func executeClearDeviationTx(
+	ctx context.Context,
+	txReq *sdcpb.TransactionSetRequest,
+) (*sdcpb.TransactionSetResponse, error) {
+	return retryClearDeviationTx(ctx, clearDeviationTxMaxAttempts, clearDeviationTxBaseBackoff,
+		func() (*sdcpb.TransactionSetResponse, error) {
+			return executeClearDeviationTxOnce(ctx, txReq)
+		})
+}
+
+// retryClearDeviationTx runs attempt up to maxAttempts times, doubling
+// backoff (starting at baseBackoff) between attempts, stopping as soon as
+// attempt succeeds or returns a non-recoverable error. Split out from
+// executeClearDeviationTx so the retry/backoff logic can be unit tested
+// without a live dataserver connection.
+func retryClearDeviationTx(
+	ctx context.Context,
+	maxAttempts int,
+	baseBackoff time.Duration,
+	attempt func() (*sdcpb.TransactionSetResponse, error),
+) (*sdcpb.TransactionSetResponse, error) {
+	backoff := baseBackoff
+	var rsp *sdcpb.TransactionSetResponse
+	var err error
+	for i := 1; i <= maxAttempts; i++ {
+		rsp, err = attempt()
+		if err == nil || i == maxAttempts || !isRecoverableClearDeviationTxError(err) {
+			return rsp, err
+		}
+		log.FromContext(ctx).Info("clear-deviation transaction hit a recoverable error, retrying",
+			"attempt", i, "backoff", backoff.String(), "error", err.Error())
+		select {
+		case <-ctx.Done():
+			return rsp, err
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return rsp, err
+}
+
+// executeClearDeviationTxOnce is a single, non-retried attempt at the
+// Set-then-Confirm sequence.
+func executeClearDeviationTxOnce(
 	ctx context.Context,
 	txReq *sdcpb.TransactionSetRequest,
 ) (*sdcpb.TransactionSetResponse, error) {
@@ -437,6 +501,26 @@ func executeClearDeviationTx(
 	}
 
 	return rsp, nil
+}
+
+// isRecoverableClearDeviationTxError mirrors pkg/sdc/target/manager's
+// isRecoverableTransactionError classification. Duplicated rather than
+// imported: pkg/sdc/target/manager already imports this package
+// (apis/config), so importing it back here would be a cycle.
+func isRecoverableClearDeviationTxError(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Aborted, codes.ResourceExhausted, codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
 }
 
 // buildClearDeviationStatus assembles the response status from the


### PR DESCRIPTION
## Problem

`kubectl sdc deviation --revert` (the `TargetClearDeviation` `cleardeviation`
subresource) calls `executeClearDeviationTx`, which issues a single,
unretried `TransactionSet` + `TransactionConfirm` against the target's
datastore.

If another transaction is already registered but not yet
`Confirm`ed/`Cancel`led on that same datastore — e.g. the `targetconfig`
reconciler mid-flight reconciling a *different* `Config`/`ConfigSet` against
the same target — data-server's `RegisterTransaction` correctly rejects the
new one with `codes.Aborted: "transaction ongoing"`. That error propagated
straight back to the CLI with zero retry, failing the revert outright.

This is what caused [sdcio/data-server#444](https://github.com/sdcio/data-server/pull/444)'s
integration tests to intermittently fail on `03-Deviations.21-Sros-Nonrevertive`:
the `Delete Deviation` keyword asserts `rc == 0` synchronously with no retry
of its own, so any single unlucky collision failed the test. That PR's own
changes are unrelated to this — confirmed by tracing the full call path.

## Change

- `executeClearDeviationTx` now retries the Set-then-Confirm sequence up to
  4 times with doubling backoff (200ms base), bounded appropriately for a
  synchronous, foreground CLI call (unlike the `targetconfig` reconciler's
  background, requeue-based backoff capped at 60s).
- Only retries on the same gRPC codes `pkg/sdc/target/manager`'s
  `isRecoverableTransactionError` already classifies as recoverable
  (`Aborted`, `ResourceExhausted`, `Unavailable`, `DeadlineExceeded`);
  bails immediately on anything else, or if the context is cancelled.
- Classification helper is duplicated locally (`isRecoverableClearDeviationTxError`)
  rather than imported, since `pkg/sdc/target/manager` already imports
  `apis/config` — importing it back would be a cycle.
- Retry loop factored into `retryClearDeviationTx` so it's unit-testable
  without a live data-server connection.

## Testing

- `TestIsRecoverableClearDeviationTxError`: classification for each gRPC code.
- `TestRetryClearDeviationTx`: succeeds without retry, retries-then-succeeds,
  stops immediately on non-recoverable errors, gives up after max attempts,
  and aborts on context cancellation.
- `go build ./...`, `go vet ./apis/config/...`, `go test ./apis/...` all pass.

Pairs-with: sdcio/data-server#444 (unblocks its flaky CI; no data-server
changes needed)

Made with [Cursor](https://cursor.com)