### PR TITLE
ci: add config-server cache-backend integration job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,3 +221,18 @@ jobs:
       certmanager_version: ${{ needs.latest-versions.outputs.certmanagerversion }}
       integration_tests_ref: ${{ needs.resolve-paired-refs.outputs.inttest_ref }}
     secrets: inherit
+
+  integration-tests-cache-backend:
+    name: integration-tests (config-server cache backend)
+    needs: [latest-versions, pr-release, resolve-paired-refs]
+    uses: sdcio/integration-tests/.github/workflows/single.yml@main
+    with:
+      configserver_version: ${{ needs.pr-release.outputs.configversion }}
+      dataserver_version: ${{ needs.resolve-paired-refs.outputs.dataversion }}
+      schemaserver_version: ${{ needs.latest-versions.outputs.schemaversion }}
+      cache_version: ${{ needs.latest-versions.outputs.cacheversion }}
+      certmanager_version: ${{ needs.latest-versions.outputs.certmanagerversion }}
+      integration_tests_ref: ${{ needs.resolve-paired-refs.outputs.inttest_ref }}
+      cache_type: config-server
+      suites_to_run: 00-setup,01-crs,05-cache-backend
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a second `single.yml` job with `cache_type: config-server` and `suites_to_run: 00-setup,01-crs,05-cache-backend`.
- Leaves the existing `integration-tests` job’s `with:` block unchanged so open PRs that never rebase stay on one job.

Depends on `sdcio/integration-tests` #116 (`cache_type` on `single.yml@main`). Until `tests/05-cache-backend` is on the checked-out integration-tests ref, that suite step no-ops; `00-setup`/`01-crs` still deploy with the config-server cache backend.

## Test plan
- [ ] This PR’s Checks show both `integration-tests` and `integration-tests (config-server cache backend)`.
- [ ] An older open PR that has not rebased still has a single integration job.
- [ ] The new job does not fail with “Unexpected input: cache_type”.


Made with [Cursor](https://cursor.com)