### PR TITLE
Proposed change to fix issue 469

### DIFF
--- a/pkg/reconcilers/targetconfig/reconciler.go
+++ b/pkg/reconcilers/targetconfig/reconciler.go
@@ -139,8 +139,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			ctx,
 			&configv1alpha1.Target{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: req.NamespacedName.Namespace,
-					Name:      req.NamespacedName.Name,
+					Namespace: req.Namespace,
+					Name:      req.Name,
 				},
 			},
 			configv1alpha1.TargetForConfigFailed("target not found"),

--- a/pkg/reconcilers/targetconfig/reconciler.go
+++ b/pkg/reconcilers/targetconfig/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sdcio/config-server/pkg/reconcilers/eventhandler"
 	"github.com/sdcio/config-server/pkg/reconcilers/resource"
 	targetmanager "github.com/sdcio/config-server/pkg/sdc/target/manager"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -132,6 +133,20 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if resource.IgnoreNotFound(err) != nil {
 			log.Error(errGetCr, "error", err)
 			return ctrl.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetCr)
+		}
+		// update the status for the config that the target is not found
+		if updateErr := r.transactor.SetConfigsTargetConditionForTarget(
+			ctx,
+			&configv1alpha1.Target{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: req.NamespacedName.Namespace,
+					Name:      req.NamespacedName.Name,
+				},
+			},
+			configv1alpha1.TargetForConfigFailed("target not found"),
+		); updateErr != nil {
+			return ctrl.Result{Requeue: true},
+				errors.Wrap(r.handleError(ctx, target, "cannot update config status", updateErr), errUpdateStatus)
 		}
 		return ctrl.Result{}, nil
 	}

--- a/pkg/sdc/target/manager/transactor.go
+++ b/pkg/sdc/target/manager/transactor.go
@@ -340,10 +340,10 @@ func (r *Transactor) setIntents(
 
 func (r *Transactor) updateConfigWithError(ctx context.Context, cfg *configv1alpha1.Config, msg string, err error, recoverable bool) error {
 	log := log.FromContext(ctx)
-	log.Warn("updateConfigWithError", 
-		"config", cfg.GetName(), 
-		"recoverable", recoverable, 
-		"msg", msg, 
+	log.Warn("updateConfigWithError",
+		"config", cfg.GetName(),
+		"recoverable", recoverable,
+		"msg", msg,
 		"err", err,
 	)
 
@@ -456,7 +456,6 @@ func (r *Transactor) updateConfigWithSuccess(
 		log.Debug("skip success update: config is deleting")
 		return nil
 	}
-	
 
 	newConfigCond := configv1alpha1.ConfigReady(msg)
 
@@ -815,12 +814,14 @@ func (r *Transactor) SetConfigsTargetConditionForTarget(
 		}
 
 		// Preserve ALL existing status fields to avoid stripping them
-		configCond := v1cfg.GetCondition(condv1alpha1.ConditionType(
-			configv1alpha1.ConfigReady("").Type,
-		))
+		configCondType := condv1alpha1.ConditionType(configv1alpha1.ConfigReady("").Type)
+		conds := []condv1alpha1.Condition{targetCond, newReadyCond}
+		if v1cfg.Status.HasCondition(configCondType) {
+			conds = append(conds, v1cfg.GetCondition(configCondType))
+		}
 
 		statusApply := configv1alpha1apply.ConfigStatus().
-			WithConditions(targetCond, configCond, newReadyCond)
+			WithConditions(conds...)
 
 		// preserve schema + appliedConfig so SSA doesn't strip them
 		if v1cfg.Status.LastKnownGoodSchema != nil {
@@ -867,11 +868,11 @@ func configSpecToApply(s *configv1alpha1.ConfigSpec) *configv1alpha1apply.Config
 	if s == nil {
 		return nil
 	}
-	
+
 	a := configv1alpha1apply.ConfigSpec().
-			WithPriority(s.Priority)
-	
-	if s.Revertive != nil {	
+		WithPriority(s.Priority)
+
+	if s.Revertive != nil {
 		a.WithRevertive(*s.Revertive)
 	}
 


### PR DESCRIPTION
* Fixed status of config when the target is not found: status is set to False, with the reason target not found.
* Fixed the empty initial status for ConfigReady: status was set to False with empty reason and error (because of GetCondition implementation that returns False status instead of nil). The fix is to preserve the condition only if it already exists in the config.
